### PR TITLE
Adding in-sync replica by topic metric rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -270,6 +270,10 @@ services:
       - name: danielqsj/kafka_exporter
         doc_url: https://github.com/danielqsj/kafka_exporter
         rules:
+        - name: Kafka Topics 
+            description: Kafka topic in-sync partition
+            query: 'sum(kafka_topic_partition_in_sync_replica) by (topic) > 3'
+            severity: error
 
   - name: Linkerd
     exporters:

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -272,7 +272,7 @@ services:
         rules:
           - name: Kafka Topics 
             description: Kafka topic in-sync partition
-            query: 'sum(kafka_topic_partition_in_sync_replica) by (topic) > 3'
+            query: 'sum(kafka_topic_partition_in_sync_replica) by (topic) < 3'
             severity: error
           - name: Kafka consumers group
             description: Kafka consumers group


### PR DESCRIPTION
In-Sync replicas less than 3 provoke the producer to raise an exception of either NotEnoughReplicas or NotEnoughReplicasAfterAppend.