### PR TITLE
correct wrong AND to OR for blackbox_exporter

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -407,7 +407,7 @@ services:
         rules:
           - name: Status Code
             description: HTTP status code is not 200-299
-            query: 'probe_http_status_code <= 199 AND probe_http_status_code >= 300'
+            query: 'probe_http_status_code <= 199 OR probe_http_status_code >= 300'
             severity: error
           - name: SSL certificate will expire soon
             description: SSL certificate expires in 30 days


### PR DESCRIPTION
Hi

The second query looks wrong to me, it tries to match `probe_http_status_code` metrics which are both equal or lower than 199 and equal or larger than 300 at the same time. I think that this "and" 
was supposed to be an "or". An "and" makes no sense.

I successfully tested the alert with "or" in our env.