### PR TITLE
Take severity value from the rule

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -84,7 +84,7 @@ groups:
   expr: {{ rule.query }}
   for: 5m
   labels:
-    severity: warning
+    severity: {{ rule.severity }}
   annotations:
     summary: "{{ rule.name }} (instance {% raw %}{{ $labels.instance }}{% endraw %})"
     description: "{{ rule.description }}\n  VALUE = {% raw %}{{ $value }}{% endraw %}\n  LABELS: {% raw %}{{ $labels }}{% endraw %}"


### PR DESCRIPTION
I've checked that all 106 rules have a severity field so the value will always be defined.