### PR TITLE
Add ProbeFailed alert for the Blackbox exporter

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -506,6 +506,10 @@ services:
       - name: prometheus/blackbox_exporter
         doc_url: https://github.com/prometheus/blackbox_exporter
         rules:
+          - name: Probe failed
+            description: Probe failed
+            query: probe_success == 0
+            severity: error
           - name: Status Code
             description: HTTP status code is not 200-299
             query: 'probe_http_status_code <= 199 OR probe_http_status_code >= 300'


### PR DESCRIPTION
This rule ensures that probe failures using http, tcp, dns and icmp are discovered.

Currently the StatusCode rule also alert on failed http probes since `probe_http_status_code` will be 0. Maybe that should be changed in order to avoid double alerting?