### PR TITLE
free memory should include node_memory_Slab_bytes

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -23,7 +23,7 @@ services:
         rules:
           - name: Out of memory
             description: Node memory is filling up (< 10% left)
-            query: '(node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes) / node_memory_MemTotal_bytes * 100 < 10'
+            query: 'node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10'
             severity: warning
           - name: Unusual network throughput in
             description: Host network interfaces are probably receiving too much data (> 100 MB/s)


### PR DESCRIPTION
Using the current expression, a node in our cluster is evaluated to have less than 10% of free memory, I hence compared the output of `free` and `cat /proc/meminfo` to learned that the `buff/cache` part is vastly different, the node isn't actually in low memory state.

Here's the output I've mentioned:

```
[root@qcloud-dev2 ~]# free
              total        used        free      shared  buff/cache   available
Mem:       16268028     6917832      168252        3616     9181944     5733016
Swap:             0           0           0
[root@qcloud-dev2 ~]# cat /proc/meminfo
MemTotal:       16268028 kB
MemFree:          170024 kB
MemAvailable:    5735232 kB
Buffers:          444924 kB
Cached:           590040 kB
SwapCached:            0 kB
Active:          7025068 kB
Inactive:         561536 kB
Active(anon):    6554744 kB
Inactive(anon):      488 kB
Active(file):     470324 kB
Inactive(file):   561048 kB
Unevictable:           0 kB
Mlocked:               0 kB
SwapTotal:             0 kB
SwapFree:              0 kB
Dirty:               552 kB
Writeback:             0 kB
AnonPages:       6551644 kB
Mapped:           106244 kB
Shmem:              3588 kB
Slab:            8147392 kB
SReclaimable:    4870128 kB
SUnreclaim:      3277264 kB
...
```

```
# Applying the current expr:
# (node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes) / node_memory_MemTotal_bytes * 100

(170024 + 590040 + 444924) / 16268028 * 100 = 7.4
```

But according to `free`, or `MemAvailable`, the node isn't in a low memory state.

I just learned this unreclaimable slab situation, this does mean my PR isn't probably doing the right thing.

Or can we just use `node_memory_MemAvailable_bytes` field as numerator?