### PR TITLE
elasticsearch: Alert for no new docs on data nodes only

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -347,7 +347,7 @@ services:
             severity: warning
           - name: Elastic no new documents
             description: No new documents for 10 min!
-            query: 'rate(elasticsearch_indices_docs{es_master_node="false"}[10m]) < 1'
+            query: 'rate(elasticsearch_indices_docs{es_data_node="true"}[10m]) < 1'
             severity: warning
 
   - name: Cassandra


### PR DESCRIPTION
We can have nodes that are not masters, but don not hold any data. For example the client/coordinating nodes set up by the `stable/elasticsearch` helm chart:
https://github.com/helm/charts/tree/master/stable/elasticsearch#client-and-coordinating-nodes

And we can also have nodes being data and master nodes simultaneously.
So I think, this alert has to look for `es_data_node="true"` to be correct.