### PR TITLE
Fix Etcd rule: Insufficient Members

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -484,7 +484,7 @@ services:
       - rules:
           - name: Insufficient Members
             description: Etcd cluster should have an odd number of members
-            query: "count(etcd_server_id) > (count(etcd_server_id) / 2 - 1)"
+            query: "count(etcd_server_id) % 2 == 0"
             severity: error
           - name: No Leader
             description: Etcd cluster have no leader


### PR DESCRIPTION
Previous rule doesn't work at all. PromQL supports modulo operation, so it's suitable to use it here.
