### PR TITLE
Adding rules for Lusitaniae/apache_exporter

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -744,7 +744,7 @@ groups:
             rules:
               - name: Apache down
                 description: Apache down
-                query: 'apache_up = 0'
+                query: 'apache_up == 0'
                 severity: error            
               - name: Apache workers load
                 description: Apache workers in busy state approach the max workers count 80% workers busy on {{ $labels.instance }}

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -742,6 +742,18 @@ groups:
           - name: Lusitaniae/apache_exporter
             doc_url: https://github.com/Lusitaniae/apache_exporter
             rules:
+              - name: Apache down
+                description: Apache down
+                query: 'apache_up = 0'
+                severity: error            
+              - name: Apache workers load
+                description: Apache workers in busy state approach the max workers count 80% workers busy on {{ $labels.instance }}
+                query: '(sum by (instance) (apache_workers{state="busy"}) / sum by (instance) (apache_scoreboard) ) * 100 > 80'
+                severity: error
+              - name: Apache restart
+                description: Apache has just been restarted, less than one minute ago.
+                query: 'apache_uptime_seconds_total / 60 < 1'
+                severity: warning
 
       - name: HaProxy
         exporters:


### PR DESCRIPTION
## Rules for Lusitaniae/apache_exporter

Added some rules for the apache_exporter :
Not to sure about the last one, maybe useless in certain cases. 

- Apache down : Apache status
- Apache workers load : If workers in busy state is to high
- Apache restart : Apache has restarted in the last minutes
