### PR TITLE
Add "Prove Monitoring Alert"

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -211,6 +211,14 @@ groups:
                 description: OOM kill detected
                 query: 'increase(node_vmstat_oom_kill[30m]) > 1'
                 severity: warning
+              - name: Host Network Receive Errors
+                description: '{{ $labels.instance}}s interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last five minutes.' 
+                query: 'increase(node_network_receive_errs_total[5m])'
+                severity: warning
+              - name: Host Network Transmit Errors
+                description: '{{ $labels.instance}}s interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last five minutes.' 
+                query: 'increase(node_network_transmit_errs_total[5m])'
+                severity: warning
 
       - name: Docker containers
         exporters:

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -113,6 +113,10 @@ groups:
               description: 'Prometheus encountered {{ $value }} TSDB WAL truncation failures'
               query: 'increase(prometheus_tsdb_wal_truncations_failed_total[3m]) > 0'
               severity: error
+            - name: Prove Monitoring
+              description: 'This is a TEST ALERT to prove that the monitoring system is fully functioning.  There is no action to be taken and it will resolve in about 5 mins.'
+              query: 'day_of_week() == 1 and count(hour() == 9 and minute() > 45 < 50 ) != 0'
+              severity: error
 
       - name: Host and hardware
         exporters:


### PR DESCRIPTION
This alert is a little different as it ensures that the monitoring system is triggered every Monday morning at the highest severity.  

This gives the team confidence that the monitoring and alerting system is working correctly, and everyone that should receive a page / email / etc gets one.