### PR TITLE
fix "Kubernetes Pod not healthy" query

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -986,7 +986,7 @@ groups:
                 severity: warning
               - name: Kubernetes Pod not healthy
                 description: Pod has been in a non-ready state for longer than an hour.
-                query: 'min_over_time(sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"} == 1)[1h:])'
+                query: 'min_over_time(sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"})[1h:]) == 1'
                 severity: error
               - name: Kubernetes pod crash looping
                 description: Pod {{ $labels.pod }} is crash looping


### PR DESCRIPTION
The alarm is now activated only after one hour of non-zero value.

I believe that this behavior was originally intended.

