### PR TITLE
fix: container ContainerMemoryUsage alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -239,7 +239,7 @@ groups:
                 severity: warning
               - name: Container Memory usage
                 description: Container Memory usage is above 80%
-                query: "(sum(container_memory_usage_bytes) BY (instance, name) / sum(container_spec_memory_limit_bytes) BY (instance, name) * 100) > 80"
+                query: "(sum(container_memory_working_set_bytes) BY (instance, name) / sum(container_spec_memory_limit_bytes) BY (instance, name) * 100) > 80"
                 severity: warning
               - name: Container Volume usage
                 description: Container Volume usage is above 80%


### PR DESCRIPTION
The `container_memory_usage_bytes` considers the cache what is not taken in consideration for OOM kill.

More info: https://medium.com/faun/how-much-is-too-much-the-linux-oomkiller-and-used-memory-d32186f29c9d