### PR TITLE
check free space for all mountpoints

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -145,8 +145,11 @@ groups:
                 severity: warning
               - name: Host out of disk space
                 description: Disk is almost full (< 10% left)
-                query: '(node_filesystem_avail_bytes{mountpoint="/rootfs"}  * 100) / node_filesystem_size_bytes{mountpoint="/rootfs"} < 10'
+                query: '(node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes < 10'
                 severity: warning
+                comments: |
+                  please add ignored mountpoints in node_exporter parameters like
+                  "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)"
               - name: Host disk will fill in 4 hours
                 description: Disk will fill in 4 hours at current write rate
                 query: 'predict_linear(node_filesystem_free_bytes{fstype!~"tmpfs"}[1h], 4 * 3600) < 0'


### PR DESCRIPTION
IMHO it would be great to call attention to a better place to deal with unnecessary mount points - at the beginning of the metric lifecycle,
instead of limiting it in alerts, at the end. 

I set up alerts based on this wonderful collection several months ago. I didn't pay attention to the label '{mountpoint="/rootfs"}' in the disk space check rule. This morning my team faced up with failed services. The reason for failure was the lack of free space. It was true - disk was 100% full. But we didn't get any notifications regarding free space. 

So, the default rule doesn't work for us. All our Ubuntu(16-18-20) & Centos(7) nodes have root file mount point as "/", not "/rootfs".

I'm assuming that having an out-of-box working rule will be useful for the community.
