### PR TITLE
Fix data-clipboard-target-id unicity

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -23,12 +23,14 @@
 
 <ul>
   {% for group in site.data.rules.groups %}
+  {% assign groupIndex = forloop.index %}
     {% for service in group.services %}
     {% assign serviceIndex = forloop.index %}
       {% for exporter in service.exporters %}
       {% assign nbrRules = exporter.rules | size %}
       <li>
-        <h2 id="{{ service.name | replace: " ", "-" | downcase }}">
+        {% assign serviceId = service.name | replace: " ", "-" | downcase %}
+        <h2 id="{{ serviceId }}">
           {{ serviceIndex }}.
           {{ service.name }}
           {% if exporter.name %}:
@@ -45,7 +47,7 @@
             <small style="font-size: 60%; vertical-align: middle; margin-left: 10px;">
               ({{ nbrRules }} rules)
             </small>
-            <span class="clipboard-multiple" data-clipboard-target-id="service-{{ serviceIndex }}">[copy all]</span>
+            <span class="clipboard-multiple" data-clipboard-target-id="group-{{ groupIndex }}-service-{{ serviceIndex }}">[copy all]</span>
           {% endif %}
         </h2>
 
@@ -64,10 +66,10 @@
               {{ serviceIndex }}.{{ ruleIndex }}.
               {{ rule.name }}
               </h4>
-            <details id="service-{{ serviceIndex }}-rule-{{ ruleIndex }}" {% if true || (serviceIndex == 1 && ruleIndex == 1) %} open {% endif %}>
+            <details id="group-{{ groupIndex }}-service-{{ serviceIndex }}-rule-{{ ruleIndex }}" {% if true || (serviceIndex == 1 && ruleIndex == 1) %} open {% endif %}>
               <summary>
                 {{ rule.description }}
-                <span class="clipboard-single" data-clipboard-target-id="service-{{ serviceIndex }}-rule-{{ ruleIndex }}" onclick="event.preventDefault();">[copy]</span>
+                <span class="clipboard-single" data-clipboard-target-id="group-{{ groupIndex }}-service-{{ serviceIndex }}-rule-{{ ruleIndex }}" onclick="event.preventDefault();">[copy]</span>
               </summary>
               <p>
               {% assign ruleName = rule.name | split: ' ' %}

--- a/rules.md
+++ b/rules.md
@@ -31,6 +31,7 @@
       <li>
         {% assign serviceId = service.name | replace: " ", "-" | downcase %}
         <h2 id="{{ serviceId }}">
+          {{ groupIndex }}.
           {{ serviceIndex }}.
           {{ service.name }}
           {% if exporter.name %}:
@@ -63,7 +64,7 @@
           {% assign comments = rule.comments | strip | newline_to_br | split: '<br />' %}
           <li>
             <h4>
-              {{ serviceIndex }}.{{ ruleIndex }}.
+              {{ groupIndex}}.{{ serviceIndex }}.{{ ruleIndex }}.
               {{ rule.name }}
               </h4>
             <details id="group-{{ groupIndex }}-service-{{ serviceIndex }}-rule-{{ ruleIndex }}" {% if true || (serviceIndex == 1 && ruleIndex == 1) %} open {% endif %}>


### PR DESCRIPTION
Service index is reset after each iteration of `group` loop, resulting in duplication of `data-clipboard-target-id` attribute. This mess up with **copy** functionality, that copies only `services` of the first group of alerts.

Adding group index should be enough, to solve this. That should fix #126 at the same time.