### PR TITLE
feat(traefik): add rules for Traefik v2

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -902,7 +902,21 @@ groups:
                 description: Traefik backend 5xx error rate is above 5%
                 query: 'sum(rate(traefik_backend_requests_total{code=~"5.*"}[3m])) by (backend) / sum(rate(traefik_backend_requests_total[3m])) by (backend) * 100 > 5'
                 severity: critical
-
+          - name: Embedded exporter v2
+            doc_url: https://docs.traefik.io/observability/metrics/prometheus/
+            rules:
+              - name: Traefik service down
+                description: All Traefik services are down
+                query: "count(traefik_service_server_up) by (service) == 0"
+                severity: critical
+              - name: Traefik high HTTP 4xx error rate service
+                description: Traefik service 4xx error rate is above 5%
+                query: 'sum(rate(traefik_service_requests_total{code=~"4.*"}[3m])) by (service) / sum(rate(traefik_service_requests_total[3m])) by (service) * 100 > 5'
+                severity: critical
+              - name: Traefik high HTTP 5xx error rate service
+                description: Traefik service 5xx error rate is above 5%
+                query: 'sum(rate(traefik_service_requests_total{code=~"5.*"}[3m])) by (service) / sum(rate(traefik_service_requests_total[3m])) by (service) * 100 > 5'
+                severity: critical
 
   - name: Runtimes
     services:


### PR DESCRIPTION
Fixes #7

Metrics in _Traefik_ v2 are basically the same except that `backends` are now referenced as `services`

```
# HELP traefik_service_request_duration_seconds How long it took to process the request on a service, partitioned by status code, protocol, and method.
# TYPE traefik_service_request_duration_seconds histogram
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="******@kubernetescrd",le="0.1"} 15
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="******@kubernetescrd",le="0.3"} 15
traefik_service_request_duration_seconds_bucket{code="200",method="GET",protocol="http",service="******@kubernetescrd",le="1.2"} 15
...
# HELP traefik_service_requests_total How many HTTP requests processed on a service, partitioned by status code, protocol, and method.
# TYPE traefik_service_requests_total counter
traefik_service_requests_total{code="200",method="GET",protocol="http",service="******@kubernetescrd"} 15
...
traefik_service_requests_total{code="401",method="GET",protocol="http",service="******@kubernetescrd"} 5
```