### PR TITLE
Fix PrometheusJobMissing alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.17.3
+   2.1.2

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -15,7 +15,7 @@ groups:
           - rules:
             - name: Prometheus job missing
               description: A Prometheus job has disappeared
-              query: 'absent(up{job="my-job"})'
+              query: 'absent(up{job="prometheus"})'
               severity: warning
             - name: Prometheus target missing
               description: A Prometheus target has disappeared. An exporter might be crashed.


### PR DESCRIPTION
By default prometheus creates target with `job="prometheus"`.

Bundler version upgraded too, otherwise latest jekyll/jekyll docker image won't start with following error:
```
$ docker run --rm -it -p 4000:4000 -v $(pwd):/srv/jekyll jekyll/jekyll jekyll serve
Traceback (most recent call last):
	2: from /usr/local/bin/bundle:23:in `<main>'
	1: from /usr/local/lib/ruby/site_ruby/2.7.0/rubygems.rb:296:in `activate_bin_path'
/usr/local/lib/ruby/site_ruby/2.7.0/rubygems.rb:277:in `find_spec_for_exe': Could not find 'bundler' (1.17.3) required by your /srv/jekyll/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.17.3`
```