### PR TITLE
Optimizing mysql slow query alert rules

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -351,8 +351,8 @@ groups:
                 query: 'mysql_slave_status_master_server_id > 0 and ON (instance) (mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay) > 300'
                 severity: warning
               - name: MySQL slow queries
-                description: MySQL server is having some slow queries.
-                query: 'mysql_global_status_slow_queries > 0'
+                description: MySQL server mysql has some new slow query.
+                query: rate(mysql_global_status_slow_queries[2m]) > 0
                 severity: warning
               - name: MySQL restarted
                 description: MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -465,6 +465,20 @@ groups:
                 query: '((sum (pg_locks_count)) / (pg_settings_max_locks_per_transaction * pg_settings_max_connections)) > 0.20'
                 severity: critical
 
+      - name: SQL Server
+        exporters:
+          - name: Ozarklake/prometheus-mssql-exporter
+            doc_url: https://github.com/Ozarklake/prometheus-mssql-exporter
+            rules:
+              - name: SQL Server down
+                description: SQl server instance is down
+                query: mssql_up == 0
+                severity: critical
+              - name: SQL Server deadlock
+                description: SQL Server is having some deadlock.
+                query: irate(mssql_deadlocks[2m]) > 0
+                severity: warning
+
       - name: PGBouncer
         exporters:
           - name: spreaker/prometheus-pgbouncer-exporter


### PR DESCRIPTION
The original rule was that the mysql server would consistently handle alarm states if a slow query was generated, which didn't seem to make sense.

The new rule is adjusted to alert only if there is a new slow query in the last 2 minutes.