### PR TITLE
Fix node_md_disks state from fail to failed

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -197,7 +197,7 @@ groups:
                 severity: critical
               - name: Host RAID disk failure
                 description: 'At least one device in RAID array on {{ $labels.instance }} failed. Array {{ $labels.md_device }} needs attention and possibly a disk swap'
-                query: 'node_md_disks{state="fail"} > 0'
+                query: 'node_md_disks{state="failed"} > 0'
                 severity: warning
               - name: Host kernel version deviations
                 description: Different kernel versions are running


### PR DESCRIPTION
Within `node_exporter` the metric `node_md_disks` exports the following states:
- Active
- Failed
- Spare

In the meantime, it had `fail` instead of `failed`. 

This information can be also confirmed on:
- [Node Exporter collector source code](https://github.com/prometheus/node_exporter/blob/master/collector/mdadm_linux.go#L146)
```go
ch <- prometheus.MustNewConstMetric(
  disksDesc,
  prometheus.GaugeValue,
  float64(mdStat.DisksFailed),
  mdStat.Name,
  "failed",
)
```
- [Node Exporter fixture for node_md_disks](https://github.com/prometheus/node_exporter/blob/master/collector/fixtures/e2e-output.txt#L1243)
```go
# HELP node_md_disks Number of active/failed/spare disks of device.
# TYPE node_md_disks gauge
node_md_disks{device="md0",state="active"} 2
node_md_disks{device="md0",state="failed"} 0
node_md_disks{device="md0",state="spare"} 0
```