### PR TITLE
Fix time unit on disk read/write latency rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -157,11 +157,11 @@ groups:
                 severity: warning
               - name: Host unusual disk read latency
                 description: Disk latency is growing (read operations > 100ms)
-                query: "rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 100"
+                query: "rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1"
                 severity: warning
               - name: Host unusual disk write latency
                 description: Disk latency is growing (write operations > 100ms)
-                query: "rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 100"
+                query: "rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 0.1"
                 severity: warning
               - name: Host high CPU load
                 description: CPU load is > 80%


### PR DESCRIPTION
The time unit on `node_disk_read_time_seconds_total` is in **seconds**, therefore if we want to evaluate against **100ms** then it should be:
```go
rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1
```

Otherwise it is evaluating **when latency if over 100 seconds**.