### PR TITLE
feat(kubernetes): add Out of capacity

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1051,6 +1051,10 @@ groups:
                 description: "{{ $labels.node }} has OutOfDisk condition"
                 query: 'kube_node_status_condition{condition="OutOfDisk",status="true"} == 1'
                 severity: critical
+              - name: Kubernetes out of capacity
+                description: "{{ $labels.node }} is out of capacity"
+                query: 'sum(kube_pod_info) by (node) / sum(kube_node_status_allocatable_pods) by (node) * 100 > 90'
+                severity: warning
               - name: Kubernetes Job failed
                 description: "Job {{$labels.namespace}}/{{$labels.exported_job}} failed to complete"
                 query: "kube_job_status_failed > 0"


### PR DESCRIPTION
Maximum number of pods per node

Typically, on EKS, while using default [Amazon VPC Container Network Interface (CNI)](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html), maximum number of pods running is dependent of AWS instance type(cf. [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI))