### PR TITLE
remove replset_oplog based alerts

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -572,10 +572,6 @@ groups:
                 description: Mongodb replication lag is more than 10s
                 query: 'avg(mongodb_replset_member_optime_date{state="PRIMARY"}) - avg(mongodb_replset_member_optime_date{state="SECONDARY"}) > 10'
                 severity: critical
-              - name: MongoDB replication headroom
-                description: MongoDB replication headroom is <= 0
-                query: '(avg(mongodb_replset_oplog_tail_timestamp - mongodb_replset_oplog_head_timestamp) - (avg(mongodb_replset_member_optime_date{state="PRIMARY"}) - avg(mongodb_replset_member_optime_date{state="SECONDARY"}))) <= 0'
-                severity: critical
               - name: MongoDB replication Status 3
                 description: MongoDB Replication set member either perform startup self-checks, or transition from completing a rollback or resync
                 query: "mongodb_replset_member_state == 3"


### PR DESCRIPTION
Removing `alert: MongodbReplicationHeadroom` since `mongodb_mongod_replset_oplog_*` have been [deprecated](https://github.com/percona/mongodb_exporter#important-note). 

> Metrics mongodb_mongod_replset_oplog_* doesn't work in Master/Slave replication mode, because it was DEPRECATED in MongoDB 3.2 and removed in 4.0.