### PR TITLE
Fix Redis missing master query

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -520,7 +520,7 @@ groups:
                 severity: critical
               - name: Redis missing master
                 description: Redis cluster has no node marked as master.
-                query: 'count(redis_instance_info{role="master"}) or vector(0) < 1'
+                query: '(count(redis_instance_info{role="master"}) or vector(0)) < 1'
                 severity: critical
               - name: Redis too many masters
                 description: Redis cluster has too many nodes marked as master.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -520,7 +520,7 @@ groups:
                 severity: critical
               - name: Redis missing master
                 description: Redis cluster has no node marked as master.
-                query: 'count(redis_instance_info{role="master"}) == 0'
+                query: 'count(redis_instance_info{role="master"}) or vector(0) < 1'
                 severity: critical
               - name: Redis too many masters
                 description: Redis cluster has too many nodes marked as master.


### PR DESCRIPTION
The previous approach fails because of the "missing data" semantics in Prometheus. If the Redis server is down, PromQL will typically return "no data" instead of 0 for a `count()`; this is by design in Prometheus.

This suggestion as given by @slovdahl works around this by returning an vector with a single `0` entry in this case, making the query work as intended.