### PR TITLE
Fix Elasticsearch "No new documents" alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -781,7 +781,7 @@ groups:
                 severity: warning
               - name: Elasticsearch no new documents
                 description: No new documents for 10 min!
-                query: 'rate(elasticsearch_indices_docs{es_data_node="true"}[10m]) < 1'
+                query: 'increase(elasticsearch_indices_docs{es_data_node="true"}[10m]) < 1'
                 severity: warning
 
       - name: Cassandra


### PR DESCRIPTION
Prometheus `rate` function calculates the per-second average rate of increase. This means the alert gets triggered whenever during last 10 minutes there was less than 1 document ingested *per second* (less than 60 documents per minute) which is not intended.