### PR TITLE
JVM alert improvement

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1071,7 +1071,7 @@ groups:
             rules:
               - name: JVM memory filling up
                 description: JVM memory is filling up (> 80%)
-                query: 'sum by (instance)(jvm_memory_used_bytes{area="heap"}) / sum by (instance)(jvm_memory_max_bytes{area="heap"}) * 100 > 80'
+                query: '(sum by (instance)(jvm_memory_used_bytes{area="heap"}) / sum by (instance)(jvm_memory_max_bytes{area="heap"})) * 100 > 80'
                 severity: warning
 
       - name: Sidekiq

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1071,7 +1071,7 @@ groups:
             rules:
               - name: JVM memory filling up
                 description: JVM memory is filling up (> 80%)
-                query: '(jvm_memory_used_bytes{area="heap"} / jvm_memory_max_bytes{area="heap"}) * 100 > 80'
+                query: 'sum by (instance)(jvm_memory_used_bytes{area="heap"}) / sum by (instance)(jvm_memory_max_bytes{area="heap"}) * 100 > 80'
                 severity: warning
 
       - name: Sidekiq


### PR DESCRIPTION
This change improves the alert by summing up all the heap area entries which include the Eden Space, Survivor Space and Tenured Gen.