### PR TITLE
Remove duplicate kubernetes job failed

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1352,10 +1352,6 @@ groups:
                 description: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
                 query: 'time() - kube_cronjob_next_schedule_time > 3600'
                 severity: warning
-              - name: Kubernetes job failed
-                description: Kubernetes Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
-                query: 'kube_job_status_failed > 0'
-                severity: critical
               - name: Kubernetes job slow completion
                 description: Kubernetes Job {{ $labels.namespace }}/{{ $labels.job_name }} did not complete in time.
                 query: 'kube_job_spec_completions - kube_job_status_succeeded > 0'


### PR DESCRIPTION
The rule I removed seems to be a duplicate of the one defined on line 1257
```
              - name: Kubernetes Job failed
                description: "Job {{$labels.namespace}}/{{$labels.exported_job}} failed to complete"
                query: 'kube_job_status_failed > 0'
                severity: warning
```

Not sure if it's because of version mismatch somewhere but the above rule did show the namespace/job correctly but for the rule I removed the labels.job_name was blank.