### PR TITLE
fix "copy" button by quoting description fields...

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -85,7 +85,7 @@
       severity: {{ rule.severity }}
     annotations:
       summary: {{ rule.name }} (instance {% raw %}{{ $labels.instance }}{% endraw %})
-      description: {{ rule.description }}\n  VALUE = {% raw %}{{ $value }}{% endraw %}\n  LABELS: {% raw %}{{ $labels }}{% endraw %}
+      description: "{{ rule.description | replace: '"', '\"' }}\n  VALUE = {% raw %}{{ $value }}{% endraw %}\n  LABELS: {% raw %}{{ $labels }}{% endraw %}"
 
 {% endhighlight %}
 


### PR DESCRIPTION
...in yaml output and escape quotes inside.

Without this change, the YAML outputted isn't valid due to ":"
characters in the description which end up throwing errors like

/etc/prometheus/rules/prometheus.rules: yaml: line 88: mapping values
are not allowed in this context.

At least with this prometheus:
```
prometheus, version 2.24.0 (branch: HEAD, revision: 02e92236a8bad3503ff5eec3e04ac205a3b8e4fe)
  build user:       root@d9f90f0b1f76
  build date:       20210106-13:48:37
  go version:       go1.15.6
  platform:         linux/amd64
```