### PR TITLE
Redis: add alternative maxmemory alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -695,9 +695,14 @@ groups:
                 description: Redis has not been backuped for 24 hours
                 query: 'time() - redis_rdb_last_save_timestamp_seconds > 60 * 60 * 24'
                 severity: critical
-              - name: Redis out of memory
-                description: Redis is running out of memory (> 90%)
+              - name: Redis out of memory (total system memory version)
+                description: Redis is running out of system memory (> 90%)
                 query: 'redis_memory_used_bytes / redis_total_system_memory_bytes * 100 > 90'
+                severity: warning
+                for: 2m
+              - name: Redis out of memory (maxmemory version)
+                description: Redis is running out of configured maxmemory (> 90%)
+                query: 'redis_memory_used_bytes / redis_memory_max_bytes * 100 > 90'
                 severity: warning
                 for: 2m
               - name: Redis too many connections


### PR DESCRIPTION
The way this was previously done works for many cases, but in our case we use the `maxmemory` setting to limit the overall Redis memory usage. Hence, the added alternative version.

(Not changed by this MR per se, but worth mentioning here: the `redis_total_system_memory_bytes` data isn't enabled in the Redis exporter unless you activate the `REDIS_EXPORTER_INCL_SYSTEM_METRICS` env variable/command line flag.)

### Redis docs about `maxmemory`

(Quoting https://raw.githubusercontent.com/redis/redis/6.0/redis.conf)

```
############################## MEMORY MANAGEMENT ################################

# Set a memory usage limit to the specified amount of bytes.
# When the memory limit is reached Redis will try to remove keys
# according to the eviction policy selected (see maxmemory-policy).
#
# If Redis can't remove keys according to the policy, or if the policy is
# set to 'noeviction', Redis will start to reply with errors to commands
# that would use more memory, like SET, LPUSH, and so on, and will continue
# to reply to read-only commands like GET.
#
# This option is usually useful when using Redis as an LRU or LFU cache, or to
# set a hard memory limit for an instance (using the 'noeviction' policy).
#
# WARNING: If you have replicas attached to an instance with maxmemory on,
# the size of the output buffers needed to feed the replicas are subtracted
# from the used memory count, so that network problems / resyncs will
# not trigger a loop where keys are evicted, and in turn the output
# buffer of replicas is full with DELs of keys evicted triggering the deletion
# of more keys, and so forth until the database is completely emptied.
#
# In short... if you have replicas attached it is suggested that you set a lower
# limit for maxmemory so that there is some free RAM on the system for replica
# output buffers (but this is not needed if the policy is 'noeviction').
#
# maxmemory <bytes>
```