### PR TITLE
Added new minio alert rules

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1846,11 +1846,19 @@ groups:
                 description: 'Minio disk is offline'
                 query: 'minio_offline_disks > 0'
                 severity: critical
+              - name: Minio disk offline
+                description: 'Minio disk is offline'
+                query: 'minio_disks_offline > 0'
+                severity: critical
               - name: Minio storage space exhausted
                 description: 'Minio storage space is low (< 10 GB)'
                 query: 'minio_disk_storage_free_bytes / 1024 / 1024 / 1024 < 10'
                 severity: warning
                 for: 2m
+              - name: Minio disk space usage
+                description: 'Minio available free space is low (< 10%)'
+                query: disk_storage_available / disk_storage_total * 100
+                severity: warning
 
       - name: SSL/TLS
         exporters:

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1844,17 +1844,8 @@ groups:
             rules:
               - name: Minio disk offline
                 description: 'Minio disk is offline'
-                query: 'minio_offline_disks > 0'
-                severity: critical
-              - name: Minio disk offline
-                description: 'Minio disk is offline'
                 query: 'minio_disks_offline > 0'
                 severity: critical
-              - name: Minio storage space exhausted
-                description: 'Minio storage space is low (< 10 GB)'
-                query: 'minio_disk_storage_free_bytes / 1024 / 1024 / 1024 < 10'
-                severity: warning
-                for: 2m
               - name: Minio disk space usage
                 description: 'Minio available free space is low (< 10%)'
                 query: disk_storage_available / disk_storage_total * 100 < 10

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1857,7 +1857,7 @@ groups:
                 for: 2m
               - name: Minio disk space usage
                 description: 'Minio available free space is low (< 10%)'
-                query: disk_storage_available / disk_storage_total * 100
+                query: disk_storage_available / disk_storage_total * 100 < 10
                 severity: warning
 
       - name: SSL/TLS


### PR DESCRIPTION
We have an old minio instance which we can apply the current alert rules on it but we also have a newer minio instance which is exposing total different metrics comparing to the older version of minio, e.g. older minio uses `minio_offline_disks` metrics to tell the number of offline disks but in the new version, it uses `minio_disks_offline` to tell the number of offline disks. I'm not sure since which version they are using the newer metrics