### PR TITLE
Improve KubernetesOutOfCapacity alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1498,7 +1498,7 @@ groups:
                 for: 2m
               - name: Kubernetes out of capacity
                 description: "{{ $labels.node }} is out of capacity"
-                query: 'sum(kube_pod_info) by (node) / sum(kube_node_status_allocatable_pods) by (node) * 100 > 90'
+                query: 'sum by (node) ((kube_pod_status_phase{phase="Running"} == 1) + on(pod, namespace) group_left(node) (0 * kube_pod_info)) / sum(kube_node_status_allocatable_pods) by (node) * 100 > 90'
                 severity: warning
                 for: 2m
               - name: Kubernetes Job failed


### PR DESCRIPTION
First off, thank you so much for sharing all these alerts! It's been super useful for us!

I'm not sure if this was the initial intention but the existing `KubernetesOutOfCapacity` alert includes pods that have any status including `Evicted`, `Completed` or `Failed` which I believe skews the metric as they are no longer using any resource on the node.

I've updated the query to only take into account Pods that have the status Running to calculate the existing capacity of the node.

Let me know if I'm missing anything.