### PR TITLE
Loki alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Collection available here: **[https://awesome-prometheus-alerts.grep.to](https:/
 #### Other
 
 - [Thanos](https://awesome-prometheus-alerts.grep.to/rules#thanos)
+- [Loki](https://awesome-prometheus-alerts.grep.to/rules#loki)
+- [Cortex](https://awesome-prometheus-alerts.grep.to/rules#cortex)
 
 ## 🤝 Contributing
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -2001,3 +2001,37 @@ groups:
                 description: Thanos compaction has not run in 24 hours.
                 query: '(time() - thanos_objstore_bucket_last_successful_upload_time) > 24*60*60'
                 severity: critical
+      - name: Loki
+        exporters:
+          - rules:
+              - name: LokiProcTooManyRestarts
+                query: changes(process_start_time_seconds{job=~"loki"}[15m]) > 2
+                for: 0m
+                severity: warning
+                annotations:
+                description: A loki process had too many restarts (target {{ $labels.instance }})
+              - name: CortexRulerConfigurationReloadFailure
+                query: cortex_ruler_config_last_reload_successful != 1
+                for: 0m
+                severity: warning
+                annotations:
+                description: Cortex ruler configuration reload failure (instance {{ $labels.instance }})
+              - name: CortexNotConnectedToAlertmanager
+                query: cortex_prometheus_notifications_alertmanagers_discovered < 1
+                for: 0m
+                severity: severe
+                annotations:
+                description: Cortex not connected to alertmanager (instance {{ $labels.instance }})
+              - name: CortexNotificationAreBeingDropped
+                query: rate(cortex_prometheus_notifications_dropped_total[5m]) > 0
+                for: 0m
+                severity: severe
+                annotations:
+                description: Cortex notification are being dropped due to errors (instance {{ $labels.instance }})
+              - name: CortexNotificationError
+                query: rate(cortex_prometheus_notifications_errors_total[5m]) > 0
+                for: 0m
+                severity: severe
+                annotations:
+                description: Cortex is failing when sengin alert notifications (instance {{ $labels.instance }})
+                

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -2004,34 +2004,26 @@ groups:
       - name: Loki
         exporters:
           - rules:
-              - name: LokiProcTooManyRestarts
-                query: changes(process_start_time_seconds{job=~"loki"}[15m]) > 2
-                for: 0m
-                severity: warning
-                annotations:
+              - name: Loki process too many restarts
                 description: A loki process had too many restarts (target {{ $labels.instance }})
-              - name: CortexRulerConfigurationReloadFailure
-                query: cortex_ruler_config_last_reload_successful != 1
-                for: 0m
+                query: changes(process_start_time_seconds{job=~"loki"}[15m]) > 2
                 severity: warning
-                annotations:
+      - name: Cortex
+        exporters:
+          - rules:
+              - name: Cortex ruler configuration reload failure
                 description: Cortex ruler configuration reload failure (instance {{ $labels.instance }})
-              - name: CortexNotConnectedToAlertmanager
+                query: cortex_ruler_config_last_reload_successful != 1
+                severity: warning
+              - name: Cortex not connected to Alertmanager
+                description: Cortex not connected to Alertmanager (instance {{ $labels.instance }})
                 query: cortex_prometheus_notifications_alertmanagers_discovered < 1
-                for: 0m
-                severity: severe
-                annotations:
-                description: Cortex not connected to alertmanager (instance {{ $labels.instance }})
-              - name: CortexNotificationAreBeingDropped
-                query: rate(cortex_prometheus_notifications_dropped_total[5m]) > 0
-                for: 0m
-                severity: severe
-                annotations:
+                severity: critical
+              - name: Cortex notification are being dropped
                 description: Cortex notification are being dropped due to errors (instance {{ $labels.instance }})
-              - name: CortexNotificationError
-                query: rate(cortex_prometheus_notifications_errors_total[5m]) > 0
-                for: 0m
-                severity: severe
-                annotations:
+                query: rate(cortex_prometheus_notifications_dropped_total[5m]) > 0
+                severity: critical
+              - name: Cortex notification error
                 description: Cortex is failing when sengin alert notifications (instance {{ $labels.instance }})
-                
+                query: rate(cortex_prometheus_notifications_errors_total[5m]) > 0
+                severity: critical


### PR DESCRIPTION
Added a few alerts for [loki](https://github.com/grafana/loki), mostly for the new alerting support.
They are quite similar to prometheus' rules.

Ps: prometheus was giving me an error on postgres [rule 23 ](https://awesome-prometheus-alerts.grep.to/rules#rule-postgresql-1-23). I solved by using a pipe and putting the query on a new line