### PR TITLE
Fix bad syntax for Haproxy rules

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1322,37 +1322,37 @@ groups:
                 severity: critical
               - name: HAProxy high HTTP 4xx error rate backend
                 description: Too many HTTP requests with status 4xx (> 5%) on backend {{ $labels.fqdn }}/{{ $labels.backend }}
-                query: 'sum by (backend) rate(haproxy_server_http_responses_total{code="4xx"}[1m]) / sum by (backend) rate(haproxy_server_http_responses_total[1m]) * 100 > 5'
+                query: 'sum by (backend) (rate(haproxy_server_http_responses_total{code="4xx"}[1m])) / sum by (backend) (rate(haproxy_server_http_responses_total[1m]) * 100) > 5'
                 severity: critical
                 for: 1m
               - name: HAProxy high HTTP 4xx error rate backend
                 description: Too many HTTP requests with status 5xx (> 5%) on backend {{ $labels.fqdn }}/{{ $labels.backend }}
-                query: 'sum by (backend) rate(haproxy_server_http_responses_total{code="5xx"}[1m]) / sum by (backend) rate(haproxy_server_http_responses_total[1m]) * 100 > 5'
+                query: 'sum by (backend) (rate(haproxy_server_http_responses_total{code="5xx"}[1m])) / sum by (backend) (rate(haproxy_server_http_responses_total[1m]) * 100) > 5'
                 severity: critical
                 for: 1m
               - name: HAProxy high HTTP 4xx error rate server
                 description: Too many HTTP requests with status 4xx (> 5%) on server {{ $labels.server }}
-                query: 'sum by (server) rate(haproxy_server_http_responses_total{code="4xx"}[1m]) / sum by (server) rate(haproxy_server_http_responses_total[1m]) * 100 > 5'
+                query: 'sum by (server) (rate(haproxy_server_http_responses_total{code="4xx"}[1m])) / sum by (server) (rate(haproxy_server_http_responses_total[1m]) * 100) > 5'
                 severity: critical
                 for: 1m
               - name: HAProxy high HTTP 5xx error rate server
                 description: Too many HTTP requests with status 5xx (> 5%) on server {{ $labels.server }}
-                query: 'sum by (server) rate(haproxy_server_http_responses_total{code="5xx"}[1m]) / sum by (server) rate(haproxy_server_http_responses_total[1m]) * 100 > 5'
+                query: 'sum by (server) (rate(haproxy_server_http_responses_total{code="5xx"}[1m])) / sum by (server) (rate(haproxy_server_http_responses_total[1m]) * 100) > 5'
                 severity: critical
                 for: 1m
               - name: HAProxy server response errors
                 description: Too many response errors to {{ $labels.server }} server (> 5%).
-                query: 'sum by (server) rate(haproxy_server_response_errors_total[1m]) / sum by (server) rate(haproxy_server_http_responses_total[1m]) * 100 > 5'
+                query: 'sum by (server) (rate(haproxy_server_response_errors_total[1m])) / sum by (server) (rate(haproxy_server_http_responses_total[1m]) * 100) > 5'
                 severity: critical
                 for: 1m
               - name: HAProxy backend connection errors
                 description: Too many connection errors to {{ $labels.fqdn }}/{{ $labels.backend }} backend (> 100 req/s). Request throughput may be to high.
-                query: 'sum by (backend) rate(haproxy_backend_connection_errors_total[1m]) > 100'
+                query: 'sum by (backend) (rate(haproxy_backend_connection_errors_total[1m])) > 100'
                 severity: critical
                 for: 1m
               - name: HAProxy server connection errors
                 description: Too many connection errors to {{ $labels.server }} server (> 100 req/s). Request throughput may be to high.
-                query: 'sum by (server) rate(haproxy_server_connection_errors_total[1m]) > 100'
+                query: 'sum by (server) (rate(haproxy_server_connection_errors_total[1m])) > 100'
                 severity: critical
               - name: HAProxy backend max active session
                 description: HAproxy backend {{ $labels.fqdn }}/{{ $labels.backend }} is reaching session limit (> 80%).
@@ -1361,7 +1361,7 @@ groups:
                 for: 2m
               - name: HAProxy pending requests
                 description: Some HAProxy requests are pending on {{ $labels.fqdn }}/{{ $labels.backend }} backend
-                query: 'sum by (backend) haproxy_backend_current_queue > 0'
+                query: 'sum by (backend) (haproxy_backend_current_queue) > 0'
                 severity: warning
                 for: 2m
               - name: HAProxy HTTP slowing down


### PR DESCRIPTION
Aggregations require parentheses around expressions