### PR TITLE
Add HostNetworkBondDegraded

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -265,6 +265,11 @@ groups:
                 query: '(rate(node_network_receive_bytes_total{device!~"^tap.*"}[1m]) + rate(node_network_transmit_bytes_total{device!~"^tap.*"}[1m])) / node_network_speed_bytes{device!~"^tap.*"} > 0.8 < 10000'    # < to 10Gb to prevent +inf when max speed is unknown
                 severity: warning
                 for: 1m
+              - name: Host Network Bond Degraded
+                description: 'Bond "{{ $labels.device }}" degraded on "{{ $labels.instance }}".'
+                query: '(node_bonding_active - node_bonding_slaves) != 0'
+                severity: warning
+                for: 2m
               - name: Host conntrack limit
                 description: 'The number of conntrack is approaching limit'
                 query: 'node_nf_conntrack_entries / node_nf_conntrack_entries_limit > 0.8'


### PR DESCRIPTION
Hi, this adds alert for network bonds. This works for us with dumb active-passive bonds as well as with LACP 802.3ad on physical hosts.