### PR TITLE
Add rule for reboot-required

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -280,6 +280,11 @@ groups:
                 query: 'min_over_time(node_timex_sync_status[1m]) == 0 and node_timex_maxerror_seconds >= 16'
                 severity: warning
                 for: 2m
+              - name: Host requires reboot
+                description: '{{ $labels.instance }} requires a reboot.'
+                query: 'node_reboot_required > 0'
+                severity: info
+                for: 4h
 
 
       - name: Docker containers


### PR DESCRIPTION
This rule checks to see if the host requires a reboot using the `node_reboot_required` metric which is generated from the script below using the textfile collector. The metric is based on the contents within the `/var/run/reboot-required` file, usually denoting that kernel updates have been installed and the host requires a reboot for them to take effect.

https://github.com/prometheus-community/node-exporter-textfile-collector-scripts/blob/master/apt.sh