### PR TITLE
fix(rule): fixing KubernetesPodNotHealthy (#215 #253)

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1584,8 +1584,9 @@ groups:
                 for: 2m
               - name: Kubernetes Pod not healthy
                 description: Pod has been in a non-ready state for longer than 15 minutes.
-                query: 'min_over_time(sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"})[15m:1m]) > 0'
+                query: 'sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"}) > 0'
                 severity: critical
+                for: 15m
               - name: Kubernetes pod crash looping
                 description: Pod {{ $labels.pod }} is crash looping
                 query: 'increase(kube_pod_container_status_restarts_total[1m]) > 3'


### PR DESCRIPTION
Hi,

I have same issue as mentioned on issues #215 and #253 . I have change the alert and test it on my clusters. With this change the alert is triggered only if the pod is in "unhealthy" state for more than 15 minutes like describe in desciption.

Short  live pods didn't trigger anymore this alert.

Regards.