### PR TITLE
The metric apiserver_request_count has been turned off

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1642,7 +1642,7 @@ groups:
                 for: 12h
               - name: Kubernetes API server errors
                 description: Kubernetes API server is experiencing high error rate
-                query: 'sum(rate(apiserver_request_count{job="apiserver",code=~"^(?:5..)$"}[1m])) / sum(rate(apiserver_request_count{job="apiserver"}[1m])) * 100 > 3'
+                query: 'sum(rate(apiserver_request_total{job="apiserver",code=~"^(?:5..)$"}[1m])) / sum(rate(apiserver_request_total{job="apiserver"}[1m])) * 100 > 3'
                 severity: critical
                 for: 2m
               - name: Kubernetes API client errors


### PR DESCRIPTION
When using this alert rule for ‘Kubernetes API client errors’, I found that the `apiserver_request_count` metric was deprecated, after searches through the documentation, it was replaced with a new metric in v1.14.

`apiserver_request_count -> apiserver_request_total`

[Kubernetes CHANGELOG-1.14](https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md)
[Kubernetes CHANGELOG-1.17](https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.17.md)