### PR TITLE
fixed erroneous usage of rate() function on gauges

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -494,12 +494,12 @@ groups:
                 severity: critical
               - name: MySQL too many connections (> 80%)
                 description: 'More than 80% of MySQL connections are in use on {{ $labels.instance }}'
-                query: 'avg by (instance) (rate(mysql_global_status_threads_connected[1m])) / avg by (instance) (mysql_global_variables_max_connections) * 100 > 80'
+                query: 'max_over_time(mysql_global_status_threads_connected[1m]) / mysql_global_variables_max_connections * 100 > 80'
                 severity: warning
                 for: 2m
               - name: MySQL high threads running
                 description: 'More than 60% of MySQL connections are in running state on {{ $labels.instance }}'
-                query: 'avg by (instance) (rate(mysql_global_status_threads_running[1m])) / avg by (instance) (mysql_global_variables_max_connections) * 100 > 60'
+                query: 'max_over_time(mysql_global_status_threads_running[1m]) / mysql_global_variables_max_connections * 100 > 60'
                 severity: warning
                 for: 2m
               - name: MySQL Slave IO thread not running


### PR DESCRIPTION
The mysql alert used to observe connection saturation "MySQL too many connections" uses the rate() function on the gauge "mysql_global_status_threads_connected". This is bound to return erroneous values since every decrease in mysql_global_status_threads_connected will be interpreted as a reset of a counter. 

Same reasoning for the seconds alert.

The new query could be even simpler:
`mysql_global_status_threads_connected / mysql_global_variables_max_connections * 100 > 80`

Depending on how often its being evaluated you might miss an intermittent peak in mysql_global_status_threads_connected.