### PR TITLE
Added Alert manager job alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -33,6 +33,10 @@ groups:
               description: Prometheus has restarted more than twice in the last 15 minutes. It might be crashlooping.
               query: 'changes(process_start_time_seconds{job=~"prometheus|pushgateway|alertmanager"}[15m]) > 2'
               severity: warning
+            - name: Prometheus AlertManager job missing
+              description: A Prometheus AlertManager job has disappeared
+              query: 'absent(up{job="alertmanager"})'
+              severity: warning
             - name: Prometheus AlertManager configuration reload failure
               description: AlertManager configuration reload error
               query: 'alertmanager_config_last_reload_successful != 1'


### PR DESCRIPTION
We are using metrics from the alert manager job (e.g. alertmanager_config_last_reload_successful ), but we are not checking if that job is actually there