### PR TITLE
Update GH action to use support ruby/setup-ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
 
     - name: Set up yq
       uses: mikefarah/yq@master


### PR DESCRIPTION
Replace unsupported [actions/setup-ruby](https://github.com/actions/setup-ruby) with support [ruby/setup-ruby](https://github.com/ruby/setup-ruby).


