### PR TITLE
fix(rule): remove RedisTooManyMasters

### DIFF
--- a/dist/rules/redis/oliver006-redis-exporter.yml
+++ b/dist/rules/redis/oliver006-redis-exporter.yml
@@ -22,15 +22,6 @@ groups:
         summary: Redis missing master (instance {{ $labels.instance }})
         description: "Redis cluster has no node marked as master.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-    - alert: RedisTooManyMasters
-      expr: 'count(redis_instance_info{role="master"}) > 1'
-      for: 0m
-      labels:
-        severity: critical
-      annotations:
-        summary: Redis too many masters (instance {{ $labels.instance }})
-        description: "Redis cluster has too many nodes marked as master.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-
     - alert: RedisDisconnectedSlaves
       expr: 'count without (instance, job) (redis_connected_slaves) - sum without (instance, job) (redis_connected_slaves) - 1 > 1'
       for: 0m

--- a/dist/rules/redis/oliver006-redis-exporter.yml
+++ b/dist/rules/redis/oliver006-redis-exporter.yml
@@ -22,6 +22,15 @@ groups:
         summary: Redis missing master (instance {{ $labels.instance }})
         description: "Redis cluster has no node marked as master.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
+    - alert: RedisTooManyMasters
+      expr: 'count(redis_instance_info{role="master",redis_mode!="cluster"}) > 1'
+      for: 0m
+      labels:
+        severity: critical
+      annotations:
+        summary: Redis too many masters (instance {{ $labels.instance }})
+        description: "Redis has too many nodes marked as master.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
     - alert: RedisDisconnectedSlaves
       expr: 'count without (instance, job) (redis_connected_slaves) - sum without (instance, job) (redis_connected_slaves) - 1 > 1'
       for: 0m


### PR DESCRIPTION
Hi. This rule doesn't seem to make sense,  because in cluster mode. multiple master nodes are normal case.  

In the official tutorial it is recommended to deploy a 3 master 3 slave cluster

```
    - alert: RedisTooManyMasters
      expr: 'count(redis_instance_info{role="master"}) > 1'
      for: 0m
      labels:
        severity: critical
      annotations:
        summary: Redis too many masters (instance {{ $labels.instance }})
        description: "Redis cluster has too many nodes marked as master.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
```