### PR TITLE
fix(rule): typo in variable name

### DIFF
--- a/dist/rules/prometheus-self-monitoring/embedded-exporter.yml
+++ b/dist/rules/prometheus-self-monitoring/embedded-exporter.yml
@@ -245,4 +245,4 @@ groups:
         severity: warning
       annotations:
         summary: Prometheus timeserie cardinality (instance {{ $labels.instance }})
-        description: "The \"{{ $label.name }}\" timeserie cardinality is getting very high: {{ $value }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        description: "The \"{{ $labels.name }}\" timeserie cardinality is getting very high: {{ $value }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
A typo was introduced in [the last commit](https://github.com/samber/awesome-prometheus-alerts/commit/f217fabb69072bd1fcbbcf2ff1ee686647398f53), causing validation to fail.

```
$ promtool check rules dist/rules/prometheus-self-monitoring/embedded-exporter.yml
Checking dist/rules/prometheus-self-monitoring/embedded-exporter.yml
  FAILED:
dist/rules/prometheus-self-monitoring/embedded-exporter.yml: group "EmbeddedExporter", rule 27, "PrometheusTimeserieCardinality": annotation "description": template: __alert_PrometheusTimeserieCardinality:1: undefined variable "$label"
```