### PR TITLE
fix: add space for labels `KubernetesJobFailed` alert rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1646,7 +1646,7 @@ groups:
                 query: '(kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1'
                 severity: warning
               - name: Kubernetes Job failed
-                description: "Job {{$labels.namespace}}/{{$labels.exported_job}} failed to complete"
+                description: "Job {{ $labels.namespace }}/{{ $labels.exported_job }} failed to complete"
                 query: 'kube_job_status_failed > 0'
                 severity: warning
               - name: Kubernetes CronJob suspended


### PR DESCRIPTION
`dist` folder is generated by `_data/rules.yml`. The #311 changes automatically reverted on https://github.com/samber/awesome-prometheus-alerts/commit/be76ab09686a262c46a90f740b848c1007f5deeb .