### PR TITLE
Reorder mysql metrics in replication alerts

### DIFF
--- a/dist/rules/mysql/mysqld-exporter.yml
+++ b/dist/rules/mysql/mysqld-exporter.yml
@@ -32,7 +32,7 @@ groups:
         description: "More than 60% of MySQL connections are in running state on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: MysqlSlaveIoThreadNotRunning
-      expr: 'mysql_slave_status_master_server_id > 0 and ON (instance) mysql_slave_status_slave_io_running == 0'
+      expr: '( mysql_slave_status_slave_io_running and ON (instance) mysql_slave_status_master_server_id > 0 ) == 0'
       for: 0m
       labels:
         severity: critical
@@ -41,7 +41,7 @@ groups:
         description: "MySQL Slave IO thread not running on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: MysqlSlaveSqlThreadNotRunning
-      expr: 'mysql_slave_status_master_server_id > 0 and ON (instance) mysql_slave_status_slave_sql_running == 0'
+      expr: '( mysql_slave_status_slave_sql_running and ON (instance) mysql_slave_status_master_server_id > 0) == 0'
       for: 0m
       labels:
         severity: critical
@@ -50,7 +50,7 @@ groups:
         description: "MySQL Slave SQL thread not running on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: MysqlSlaveReplicationLag
-      expr: 'mysql_slave_status_master_server_id > 0 and ON (instance) (mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay) > 30'
+      expr: '( (mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay) and ON (instance) mysql_slave_status_master_server_id > 0 ) > 30'
       for: 1m
       labels:
         severity: critical


### PR DESCRIPTION
The three replication formulas as written were using the value of the server ID (left hand side) instead of the values for io running, sql running, and lag.  On our systems, it immediately alerts and stays open because the server id is > 30 (for lag) and is > 0 (for io running and sql running state).

This change puts the value that needs to be compared on the left hand side of the formula, per the "PromQL Operators" section of the docs (emphasis added by me) :

> `vector1` and `vector2` results in a vector consisting of the elements of `vector1` for which there are elements in `vector2` with exactly matching label sets. Other elements are dropped. **The metric name and values are carried over from the left-hand side vector.**

I am not a promql expert so if there is a better or more readable way to adjust these three rules, please feel free to make recommendations.