### PR TITLE
5.1.27 make expr result positive

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1755,7 +1755,7 @@ groups:
                 for: 1m
               - name: Kubernetes CronJob too long
                 description: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
-                query: 'time() - kube_cronjob_next_schedule_time > 3600'
+                query: 'kube_cronjob_next_schedule_time - time() > 3600'
                 severity: warning
                 comments: |
                   Threshold should be customized for each cronjob name.


### PR DESCRIPTION
5.1.27 kubernetes CronJob too long
time() is smaller than kube_cronjob_next_schedule_time.
so `time() - kube_cronjob_next_schedule_time` is always negative value.
I think it should be `kube_cronjob_next_schedule_time - time() > 3600`.