### PR TITLE
Cert rules issues

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -389,15 +389,15 @@ groups:
                 severity: critical
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in less than 20 days
-                query: '86400 * 3 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 20'
+                query: '3 <= round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 20'
                 severity: warning
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in less than 3 days
-                query: '0 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 3'
+                query: '0 <= round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 3'
                 severity: critical
               - name: Blackbox SSL certificate expired
                 description: SSL certificate has expired already
-                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 0'
+                query: 'round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 0'
                 severity: critical
                 comments: |
                   For probe_ssl_earliest_cert_expiry to be exposed after expiration, you

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -389,15 +389,15 @@ groups:
                 severity: critical
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in 30 days
-                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 30'
+                query: '86400 * 3 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 30'
                 severity: warning
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in 3 days
-                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 3'
+                query: '0 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 3'
                 severity: critical
               - name: Blackbox SSL certificate expired
                 description: SSL certificate has expired already
-                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() <= 0'
+                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 0'
                 severity: critical
                 comments: |
                   For probe_ssl_earliest_cert_expiry to be exposed after expiration, you

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -399,6 +399,11 @@ groups:
                 description: SSL certificate has expired already
                 query: 'probe_ssl_earliest_cert_expiry - time() <= 0'
                 severity: critical
+                comments: |
+                  For probe_ssl_earliest_cert_expiry to be exposed after expiration, you
+                  need to enable insecure_skip_verify. Note that this will disable
+                  certificate validation.
+                  See https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md#tls_config
               - name: Blackbox probe slow HTTP
                 description: HTTP request took more than 1s
                 query: 'avg_over_time(probe_http_duration_seconds[1m]) > 1'

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -388,8 +388,8 @@ groups:
                 query: 'probe_http_status_code <= 199 OR probe_http_status_code >= 400'
                 severity: critical
               - name: Blackbox SSL certificate will expire soon
-                description: SSL certificate expires in 30 days
-                query: '86400 * 3 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 30'
+                description: SSL certificate expires in 20 days
+                query: '86400 * 3 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 20'
                 severity: warning
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in 3 days

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -388,11 +388,11 @@ groups:
                 query: 'probe_http_status_code <= 199 OR probe_http_status_code >= 400'
                 severity: critical
               - name: Blackbox SSL certificate will expire soon
-                description: SSL certificate expires in 20 days
+                description: SSL certificate expires in less than 20 days
                 query: '86400 * 3 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 20'
                 severity: warning
               - name: Blackbox SSL certificate will expire soon
-                description: SSL certificate expires in 3 days
+                description: SSL certificate expires in less than 3 days
                 query: '0 <= last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 3'
                 severity: critical
               - name: Blackbox SSL certificate expired

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -389,15 +389,15 @@ groups:
                 severity: critical
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in 30 days
-                query: 'probe_ssl_earliest_cert_expiry - time() < 86400 * 30'
+                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 30'
                 severity: warning
               - name: Blackbox SSL certificate will expire soon
                 description: SSL certificate expires in 3 days
-                query: 'probe_ssl_earliest_cert_expiry - time() < 86400 * 3'
+                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() < 86400 * 3'
                 severity: critical
               - name: Blackbox SSL certificate expired
                 description: SSL certificate has expired already
-                query: 'probe_ssl_earliest_cert_expiry - time() <= 0'
+                query: 'last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time() <= 0'
                 severity: critical
                 comments: |
                   For probe_ssl_earliest_cert_expiry to be exposed after expiration, you


### PR DESCRIPTION
Relates to issue #327 

1. add **comment** for [BlackboxSslCertificateExpired](https://awesome-prometheus-alerts.grep.to/rules#rule-blackbox-1-7)  to make clear that this rule will only work when `insecure_skip_verify` is enabled in the *blackbox_exporter* module.
2. use [last_over_time](https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time) in all three certificate rules to make them less prone to alert flapping. Alert flapping can happen when metrics disappear which can happen when a scrape/probe fails.
3. add **lower bound thresholds** on [BlackboxSslCertificateWillExpireSoon](https://awesome-prometheus-alerts.grep.to/rules#rule-blackbox-1-5) rules to avoid overlap. When time-to-expire < 0, it is also < 3 and < 30. This way no `inhibit_rules` are necessary in *Alertmanager*.
4. changed *upper bound threshold* for [BlackboxSslCertificateWillExpireSoon](https://awesome-prometheus-alerts.grep.to/rules#rule-blackbox-1-5) to **20** days. This is what Let's Encrypt use in their [email notifications](https://letsencrypt.org/docs/expiration-emails/). Most importantly it avoids false alarms since 30 days is the renewal threshold in [certbot](https://eff-certbot.readthedocs.io/en/stable/using.html#renewing-certificates) and other ACME clients and the scheduled jobs are usually weekly.
5. add "less than" in the description of both [BlackboxSslCertificateWillExpireSoon](https://awesome-prometheus-alerts.grep.to/rules#rule-blackbox-1-5) rules to make them clearer.
6. use days in certificate rules queries to improve notification values.
