### PR TITLE
Add APC UPS & ZFS exporter

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -2080,6 +2080,30 @@ groups:
                 query: 'node_zfs_zpool_state{state!="online"} > 0'
                 severity: critical
                 for: 1m
+          - name: ZFS exporter
+            slug: zfs_exporter
+            doc_url: https://github.com/pdf/zfs_exporter
+            rules:
+              - name: ZFS pool out of space
+                description: Disk is almost full (< 10% left)
+                query: 'zfs_pool_free_bytes * 100 / zfs_pool_size_bytes < 10 and ON (instance, device, mountpoint) zfs_pool_readonly == 0'
+                severity: warning
+              - name: ZFS pool unhealthy
+                description: ZFS pool state is {{ $value }}. See comments for more information.
+                query: 'zfs_pool_health > 0'
+                severity: critical
+                comments: |
+                  0: ONLINE
+                  1: DEGRADED
+                  2: FAULTED
+                  3: OFFLINE
+                  4: UNAVAIL
+                  5: REMOVED
+                  6: SUSPENDED
+              - name: ZFS collector failed
+                description: ZFS collector for {{ $labels.instance }} has failed to collect information
+                query: 'zfs_scrape_collector_success != 1'
+                severity: warning
 
       - name: OpenEBS
         exporters:

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -2353,3 +2353,35 @@ groups:
                   * FAILURE   2 false - The build had a fatal error.
                   * NOT_BUILT 3 false - The module was not built.
                   * ABORTED   4 false - The build was manually aborted.
+
+      - name: APC UPS
+        exporters:
+          - name: mdlayher/apcupsd_exporter
+            slug: apcupsd_exporter
+            doc_url: https://github.com/mdlayher/apcupsd_exporter
+            rules:
+              - name: APC UPS Battery nearly empty
+                description: Battery is almost empty (< 10% left)
+                query: 'apcupsd_battery_charge_percent < 10'
+                severity: critical
+              - name: APC UPS Less than 15 Minutes of battery time remaining
+                description: Battery is almost empty (< 15 Minutes remaining)
+                query: 'apcupsd_battery_time_left_seconds < 900'
+                severity: critical
+              - name: APC UPS AC input outage
+                description: UPS now running on battery (since {{$value | humanizeDuration}})
+                query: 'apcupsd_battery_time_on_seconds > 0'
+                severity: warning
+              - name: APC UPS low battery voltage
+                description: Battery voltage is lower than nominal (< 95%)
+                query: '(apcupsd_battery_volts / apcupsd_battery_nominal_volts) < 0.95'
+                severity: warning
+              - name: APC UPS high temperature
+                description: Internal temperature is high ({{$value}}°C)
+                query: 'apcupsd_internal_temperature_celsius >= 40'
+                severity: warning
+                for: 2m
+              - name: APC UPS high load
+                description: UPS load is > 80%
+                query: 'apcupsd_ups_load_percent > 80'
+                severity: warning


### PR DESCRIPTION
I know there's a node exporter metric for ZFS, but on my proxmox host node exporter is not built with it enabled. So better to have both I think.