### PR TITLE
Ignore temperature from tctl sensors

### DIFF
--- a/dist/rules/host-and-hardware/node-exporter.yml
+++ b/dist/rules/host-and-hardware/node-exporter.yml
@@ -194,7 +194,7 @@ groups:
         description: "systemd service crashed\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: HostPhysicalComponentTooHot
-      expr: 'node_hwmon_temp_celsius > 75'
+      expr: 'node_hwmon_temp_celsius * ignoring(label) group_left(instance, job, node, sensor) node_hwmon_sensor_label{label!="tctl"} > 75'
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
Ignore temperature from tctl sensors: the tctl sensor is not a real hardware component and will report numbers in the 80's or 90's thus triggering the alarm even when the cores are around 30c.