### PR TITLE
Fix MongoDB replication headroom query

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -792,7 +792,7 @@ groups:
                 severity: critical
               - name: MongoDB replication headroom
                 description: MongoDB replication headroom is <= 0
-                query: 'sum(avg(mongodb_oplog_stats_start - mongodb_oplog_stats_end)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
+                query: 'sum(avg(mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
                 severity: critical
               - name: MongoDB number cursors open
                 description: Too many cursors opened by MongoDB for clients (> 10k)


### PR DESCRIPTION
The query was changed to use `mongodb_oplog_stats_start` and `mongodb_oplog_stats_end` in #291 but these metrics does not represent the start and end of the oplog. The original head and tail metrics are calculated from the oplog and are consistent with the output of `db.getReplicationInfo()`.