### PR TITLE
fix(nginx): fix nginx query for histogram_percentile

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1371,7 +1371,7 @@ groups:
                 for: 1m
               - name: Nginx latency high
                 description: Nginx p99 latency is higher than 3 seconds
-                query: 'histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node)) > 3'
+                query: 'histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket[2m])) by (host, node, le)) > 3'
                 severity: warning
                 for: 2m
 


### PR DESCRIPTION
It seems that from my point of view the `nginx latency` rule is missing a parameter for the sum (`le`).
Indeed, this query needs to have the `le` inside the sum if you want to work with quantile.

It's close to the following comment : https://github.com/samber/awesome-prometheus-alerts/issues/292#issuecomment-1175848201

Thanks ! :)
