### PR TITLE
Fix `Redis disconnected slaves` off-by-one

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -742,7 +742,7 @@ groups:
                 severity: critical
               - name: Redis disconnected slaves
                 description: Redis not replicating for all slaves. Consider reviewing the redis replication status.
-                query: 'count without (instance, job) (redis_connected_slaves) - sum without (instance, job) (redis_connected_slaves) - 1 > 1'
+                query: 'count without (instance, job) (redis_connected_slaves) - sum without (instance, job) (redis_connected_slaves) - 1 > 0'
                 severity: critical
               - name: Redis replication broken
                 description: Redis instance lost a slave


### PR DESCRIPTION
From my naive understanding, suppose we have 2 redis instances (1x master, 1x slave). Then, I observe `redis_connected_slaves` has two series, one having value 1 and another having value 0.

Then, `count` gives 2 and `sum` gives 1. Thus LHS yields `2 - 1 - 1 = 0`.

Now, suppose the slave is disconnected. Then the LHS yields `2 - 0 - 1 = 1`. So we should set `>0` not `>1` as condition.