### PR TITLE
Update Clock Skew Offset

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -317,7 +317,7 @@ groups:
                 description: 'Clock skew detected. Clock is out of sync. Ensure NTP is configured correctly on this host.'
                 query: '((node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)) * on(instance) group_left (nodename) node_uname_info{nodename=~".+"}'
                 severity: warning
-                for: 2m
+                for: 10m
               - name: Host clock not synchronising
                 description: 'Clock not synchronising. Ensure NTP is configured on this host.'
                 query: '(min_over_time(node_timex_sync_status[1m]) == 0 and node_timex_maxerror_seconds >= 16) * on(instance) group_left (nodename) node_uname_info{nodename=~".+"}'


### PR DESCRIPTION
If the host clock is out of sync NTP will gradually correct it. `10m` should be a sufficient time for the system clock to correct while preventing false positives alerts. 