### PR TITLE
Fix typo "critial" in receiver routes

### DIFF
--- a/alertmanager.md
+++ b/alertmanager.md
@@ -80,7 +80,7 @@ route:
     - receiver: "pager"
       group_wait: 10s
       match_re:
-        severity: critial
+        severity: critical
       continue: true
 
 receivers:


### PR DESCRIPTION
This typo would cause the example pager route to never be triggered.