### PR TITLE
RedisOutOfConfiguredMaxmemory: checking if memory limit is set

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -821,7 +821,7 @@ groups:
                   The exporter must be started with --include-system-metrics flag or REDIS_EXPORTER_INCL_SYSTEM_METRICS=true environment variable.
               - name: Redis out of configured maxmemory
                 description: Redis is running out of configured maxmemory (> 90%)
-                query: "redis_memory_used_bytes / redis_memory_max_bytes * 100 > 90"
+                query: "redis_memory_used_bytes / redis_memory_max_bytes * 100 > 90 and on(instance) redis_memory_max_bytes > 0"
                 severity: warning
                 for: 2m
               - name: Redis too many connections


### PR DESCRIPTION
If memory limit for Redis instance is not set then redis_memory_max_bytes metric equals 0 - https://github.com/oliver006/redis_exporter?tab=readme-ov-file#the-redis_memory_max_bytes-metric

In that case expression `redis_memory_used_bytes / redis_memory_max_bytes * 100 > 90` return `+Inf` that fires RedisOutOfConfiguredMaxmemory alert.

So we additionally need to check `redis_memory_max_bytes > 0` condition