### PR TITLE
add new alerts for elasticsearch rules.yml

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1128,6 +1128,26 @@ groups:
                 description: No new documents for 10 min!
                 query: 'increase(elasticsearch_indices_indexing_index_total{es_data_node="true"}[10m]) < 1'
                 severity: warning
+              - name: Elasticsearch High Indexing Latency
+                description: "The indexing latency on Elasticsearch cluster is higher than the threshold."
+                query: "elasticsearch_indices_indexing_index_time_seconds_total / elasticsearch_indices_indexing_index_total > 0.0005"
+                severity: warning
+                for: 10m       
+              - name: Elasticsearch High Indexing Rate
+                description: "The indexing rate on Elasticsearch cluster is higher than the threshold."
+                query: "elasticsearch_indices_indexing_index_total > 100000"
+                severity: warning
+                for: 5m     
+              - name: Elasticsearch High Query Rate
+                description: "The query rate on Elasticsearch cluster is higher than the threshold."
+                query: "elasticsearch_indices_search_query_total > 100000"
+                severity: warning
+                for: 5m
+              - name: Elasticsearch High Query Latency
+                description: "The query latency on Elasticsearch cluster is higher than the threshold."
+                query: "elasticsearch_indices_search_fetch_time_seconds / elasticsearch_indices_search_fetch_total > 1"
+                severity: warning
+                for: 5m                 
 
       - name: Cassandra
         exporters:


### PR DESCRIPTION
This merge request adds new alert definitions for monitoring indexing and query metrics related to Elasticsearch. These alerts are crucial for detecting and mitigating potential performance issues in Elasticsearch clusters.