### PR TITLE
RabbitMQ: add too many ready messages alert

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -969,6 +969,11 @@ groups:
                 query: "rabbitmq_process_open_fds / rabbitmq_process_max_fds * 100 > 90"
                 severity: warning
                 for: 2m
+              - name: RabbitMQ too many ready messages
+                description: RabbitMQ too many ready messages on {{ $labels.instace }}
+                query: "sum(rabbitmq_queue_messages_ready) BY (queue) > 1000"
+                severity: warning
+                for: 1m
               - name: RabbitMQ too many unack messages
                 description: Too many unacknowledged messages
                 query: "sum(rabbitmq_queue_messages_unacked) BY (queue) > 1000"

--- a/dist/rules/rabbitmq/rabbitmq-exporter.yml
+++ b/dist/rules/rabbitmq/rabbitmq-exporter.yml
@@ -49,6 +49,15 @@ groups:
         summary: RabbitMQ file descriptors usage (instance {{ $labels.instance }})
         description: "A node use more than 90% of file descriptors\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
+    - alert: RabbitmqTooManyReadyMessages
+      expr: 'sum(rabbitmq_queue_messages_ready) BY (queue) > 1000'
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: RabbitMQ too many ready messages (instance {{ $labels.instance }})
+        description: "Too many ready messages\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
     - alert: RabbitmqTooManyUnackMessages
       expr: 'sum(rabbitmq_queue_messages_unacked) BY (queue) > 1000'
       for: 1m


### PR DESCRIPTION
This alert might be useful for systems that aren't 100% stable. In my case I didn't notice that my consumers stopped at a point, and as a result, ready messages piled up to half a million.