### PR TITLE
fix missing parentheses in node-exporter rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -197,7 +197,7 @@ groups:
                 for: 2m
               - name: Host unusual disk read latency
                 description: Disk latency is growing (read operations > 100ms)
-                query: "(rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0"
+                query: "(rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0)"
                 severity: warning
                 for: 2m
               - name: Host unusual disk write latency


### PR DESCRIPTION
Added missing parentheses to a `node-exporter` rule, which led to parsing error

```
bad prometheus expr: "(rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0", err: parensExpr: unexpected token ""; want "," or ")"; unparsed data: ""
```