### PR TITLE
Added PostgresqlReplicationLagHigh rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -747,6 +747,11 @@ groups:
                 for: 6h
                 comments: |
                   See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
+              - name: Postgresql replication lag high (> 60s)
+                description: The PostgreSQL replication lag is high
+                query: "pg_replication_lag_seconds > 60"
+                severity: warning
+                for: 2m
 
       - name: SQL Server
         exporters:

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -747,11 +747,11 @@ groups:
                 for: 6h
                 comments: |
                   See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
-              - name: Postgresql replication lag high (> 60s)
-                description: The PostgreSQL replication lag is high
-                query: "pg_replication_lag_seconds > 60"
+              - name: Postgresql replication lag high
+                description: The PostgreSQL replication lag is high (> 60s)
+                query: "pg_replication_lag_seconds > 5"
                 severity: warning
-                for: 2m
+                for: 30s
 
       - name: SQL Server
         exporters:

--- a/dist/rules/postgresql/postgres-exporter.yml
+++ b/dist/rules/postgresql/postgres-exporter.yml
@@ -192,3 +192,12 @@ groups:
       annotations:
         summary: Postgresql invalid index (instance {{ $labels.instance }})
         description: "The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}. You should execute `DROP INDEX {{ $labels.indexrelname }};`\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+    - alert: PostgresqlReplicationLagHigh
+      expr: 'pg_replication_lag_seconds > 60'
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: Postgresql replication lag high (> 60s) (instance {{ $labels.instance }})
+        description: "The PostgreSQL replication lag is high\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
First of all, thank you so much for providing these awesome alert rules! 🙂 Keep up the great work

This PR adds a `PostgresqlReplicationLagHigh` rule that triggers when the **replication lag** is higher than **60 seconds**. This should help teams detect **potential replication issues** before they become critical.

I hope it can be a good addition :) let me know what you think