### PR TITLE
haproxy: align v1 and v2 HAProxy backend max active session > 80% alerts

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1943,7 +1943,7 @@ groups:
                 query: (sum by (proxy) (rate(haproxy_server_connection_errors_total[1m]))) > 100
                 severity: critical
               - name: HAProxy backend max active session > 80%
-                description: Session limit from backend {{ $labels.proxy }} to server {{ $labels.server }} reached 80% of limit - {{ $value | printf "%.2f"}}%
+                description: Session limit from backend {{ $labels.proxy }} reached 80% of limit - {{ $value | printf "%.2f"}}%
                 query: ((haproxy_backend_current_sessions >0) * 100) / (haproxy_backend_limit_sessions > 0) > 80
                 severity: warning
                 for: 2m

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1944,7 +1944,7 @@ groups:
                 severity: critical
               - name: HAProxy backend max active session > 80%
                 description: Session limit from backend {{ $labels.proxy }} to server {{ $labels.server }} reached 80% of limit - {{ $value | printf "%.2f"}}%
-                query: ((haproxy_server_max_sessions >0) * 100) / (haproxy_server_limit_sessions > 0) > 80
+                query: ((haproxy_backend_current_sessions >0) * 100) / (haproxy_backend_limit_sessions > 0) > 80
                 severity: warning
                 for: 2m
               - name: HAProxy pending requests


### PR DESCRIPTION
The alert "HAProxy backend max active sessions > 80%" for the V2 exporter is not aligned with the one from the V1 exporter, which [received a fix](https://github.com/samber/awesome-prometheus-alerts/pull/413) to use the metrics that expose the current values instead of a monothonic increasing value. 

This PR aims to align the behavior on both exporters using the correct metrics also in V2