### PR TITLE
feat/dual license

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
           cache: npm
           cache-dependency-path: site/package-lock.json
 

--- a/site/LICENSE
+++ b/site/LICENSE
@@ -1,22 +1,4 @@
-This repository uses a dual license:
-
-- Alert rules and content (_data/rules.yml, dist/rules/, README.md):
-  Creative Commons Attribution 4.0 International (CC BY 4.0)
-  https://creativecommons.org/licenses/by/4.0/
-
-- Site source code (site/):
-  MIT License
-  https://opensource.org/licenses/MIT
-
----
-
-Creative Commons Attribution 4.0 International License (CC BY 4.0)
-
-http://creativecommons.org/licenses/by/4.0/
-
----
-
-MIT License (site source code)
+MIT License
 
 Copyright (c) 2018 Samuel Berthe
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import { sponsors } from '../data/sponsors';
 import { getPopularServices, data, getGroupSlug } from '../data/rules';
-import { SITE_NAME, SITE_URL, GITHUB_URL, GITHUB_CONTRIBUTING_URL, GITHUB_LICENSE_URL, AUTHOR_NAME, AUTHOR_GITHUB_URL, TWITTER_HANDLE, LICENSE_CC_BY_NAME } from '../data/site';
+import { SITE_NAME, SITE_URL, GITHUB_URL, GITHUB_CONTRIBUTING_URL, GITHUB_LICENSE_URL, GITHUB_MIT_LICENSE_URL, AUTHOR_NAME, AUTHOR_GITHUB_URL, TWITTER_HANDLE, LICENSE_CC_BY_NAME, LICENSE_MIT_NAME } from '../data/site';
 
 interface Props {
   base: string;
@@ -90,7 +90,11 @@ const featuredGroups = data.groups.filter((g) => featuredGroupSlugs.includes(get
         {' '}is maintained by{' '}
         <a href={AUTHOR_GITHUB_URL} class="hover:text-brand dark:hover:text-brand-dark transition-colors">@{AUTHOR_GITHUB_URL.split('/').pop()}</a>
       </span>
-      <span>Licensed under <a href={GITHUB_LICENSE_URL} class="hover:text-brand dark:hover:text-brand-dark transition-colors">{LICENSE_CC_BY_NAME}</a></span>
+      <span>
+        Alert rules: <a href={GITHUB_LICENSE_URL} class="hover:text-brand dark:hover:text-brand-dark transition-colors">{LICENSE_CC_BY_NAME}</a>
+        {' · '}
+        Site code: <a href={GITHUB_MIT_LICENSE_URL} class="hover:text-brand dark:hover:text-brand-dark transition-colors">{LICENSE_MIT_NAME}</a>
+      </span>
     </div>
   </div>
 </footer>

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -21,6 +21,8 @@ export const GITHUB_LICENSE_URL = `${GITHUB_URL}/blob/master/LICENSE`;
 export const LICENSE_CC_BY_URL = 'https://creativecommons.org/licenses/by/4.0/';
 export const LICENSE_CC_BY_NAME = 'Creative Commons CC BY 4.0';
 export const LICENSE_MIT_URL = 'https://opensource.org/licenses/MIT';
+export const LICENSE_MIT_NAME = 'MIT';
+export const GITHUB_MIT_LICENSE_URL = `${GITHUB_URL}/blob/master/site/LICENSE`;
 
 export const schemaAuthor = {
   '@type': 'Person',

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -100,7 +100,7 @@ const faqItems = [
     name: 'What is the license for these alert rules?',
     acceptedAnswer: {
       '@type': 'Answer',
-      text: `The alert rules are licensed under Creative Commons CC BY 4.0. You are free to use, adapt, and redistribute them — including in commercial environments — as long as you provide attribution. See the LICENSE file in the GitHub repository for details.`,
+      text: `The alert rules and content are licensed under Creative Commons CC BY 4.0 — you are free to use, adapt, and redistribute them, including commercially, as long as you provide attribution. The site source code is licensed under MIT. See the LICENSE file in the GitHub repository for details.`,
     },
   },
 ];


### PR DESCRIPTION
- **ci: remove node version pin in site build workflow**
- **docs: clarify dual license (CC BY 4.0 for content, MIT for site code)**
