### PR TITLE
Add LiteLLM section to Other group (3 alerting rules)

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -5918,3 +5918,28 @@ groups:
                 severity: critical
                 comments: |
                   Threshold of 20ms. Adjust based on your expected database latency.
+
+      - name: LiteLLM
+        exporters:
+          - slug: embedded-exporter
+            doc_url: https://docs.litellm.ai/docs/proxy/prometheus
+            rules:
+              - name: LiteLLM provider spend over budget
+                description: "Cumulative spend for an LLM provider has exceeded the daily budget threshold. Replace the regex `(claude-|anthropic/).*` with your provider's model-name pattern. Useful as a soft-warning when `provider_budget_config` hard-cap is unavailable or disabled."
+                query: 'sum(increase(litellm_spend_metric_total{model=~"(claude-|anthropic/).*"}[24h])) > 1'
+                severity: warning
+                for: 5m
+                comments: |
+                  The threshold (1) is in USD. The `model` label carries the resolved model-name (post-routing). 
+                  PromQL `increase()` requires ≥2 datapoints with growth-difference to extrapolate positive — 
+                  for brand-new counter series this needs ≥2 distinct request bursts ≥1 scrape-cycle apart.
+              - name: LiteLLM proxy failed requests rate high
+                description: "LiteLLM proxy is returning failed responses to clients (>5% error rate over 5min). Investigate downstream LLM provider availability or auth issues."
+                query: 'sum(rate(litellm_proxy_failed_requests_metric_total[5m])) / sum(rate(litellm_proxy_total_requests_metric_total[5m])) > 0.05'
+                severity: warning
+                for: 10m
+              - name: LiteLLM request latency p95 high
+                description: "LiteLLM request total latency p95 exceeds 10 seconds over 5min. Check downstream LLM provider response-times and proxy queue-depth."
+                query: 'histogram_quantile(0.95, sum(rate(litellm_request_total_latency_metric_bucket[5m])) by (le)) > 10'
+                severity: warning
+                for: 10m


### PR DESCRIPTION
## Context

[LiteLLM](https://github.com/BerriAI/litellm) is a widely-used LLM-gateway/proxy that exposes Prometheus metrics via its built-in callback. Currently there's no LiteLLM section in this repo, despite its adoption as an OpenAI/Anthropic-compatible proxy in many production stacks.

## What this PR adds

3 alerting rules under a new `LiteLLM` service in the `Other` group:

1. **LiteLLM provider spend over budget** — soft-warning on cumulative 24h spend per model-name regex. Useful when LiteLLM's native `provider_budget_config` hard-cap is unavailable, disabled, or buggy (we hit such a bug, see [BerriAI/litellm#26701](https://github.com/BerriAI/litellm/issues/26701)).

2. **LiteLLM proxy failed requests rate high** — error-rate ratio alert for downstream LLM provider availability/auth issues.

3. **LiteLLM request latency p95 high** — histogram-quantile alert for downstream provider response-time degradation.

## Validation

- All 3 rules: `promtool check rules` returns `SUCCESS: 3 rules found`.
- Validated on a real LiteLLM v1.83.7 production deployment.
- The spend rule (`AnthropicSpend24hOverBudget` in our deployment) was end-to-end tested via real haiku-call → alert fires → Telegram-routed → resolved post-revert.

## Notes for reviewers

- The `(claude-|anthropic/).*` regex in the spend-rule example is just one provider-pattern; users will customize for their own providers (`openai-`, `gpt-`, `gemini-`, etc.). The description explicitly notes this.
- The spend-counter has a known first-value-problem on brand-new series (PromQL `increase()` needs ≥2 datapoints with growth-difference). Documented in the rule's `comments:` field.
- All 3 metrics (`litellm_spend_metric_total`, `litellm_proxy_failed_requests_metric_total`, `litellm_proxy_total_requests_metric_total`, `litellm_request_total_latency_metric_bucket`) are exposed by LiteLLM's built-in `prometheus` callback (no separate exporter needed).

## Reference

- LiteLLM Prometheus docs: https://docs.litellm.ai/docs/proxy/prometheus