### PR TITLE
fix(ci): fix Publish workflow startup_failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,6 @@ permissions:
 jobs:
   publish:
     name: Publish
-    # Check if the PR is not from a fork
-    if: github.repository_owner == 'samber'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -22,15 +20,15 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: '3.4'
 
       - name: Set up yq
         uses: mikefarah/yq@v4
 
       - name: Install liquid
         run: |
-         gem install liquid -v 5.5.1
-         gem install liquid-cli 
+          gem install liquid -v 5.5.1
+          gem install liquid-cli
 
       - name: Build rule configuration
         run: |
@@ -43,7 +41,7 @@ jobs:
             mkdir -p "${subdir}"
 
             # groupName=$(echo "{% assign groupName = name | split: ' ' %}{% capture groupNameCamelcase %}{% for word in groupName %}{{ word | capitalize }} {% endfor %}{% endcapture %} {{ groupNameCamelcase | remove: ' ' | remove: '-' }}" | liquid $(echo ${service} | base64 --decode | jq -r '.name | ascii_downcase | split(" ") | join("-")'))
-    
+
             for exporter in $(echo ${service} | base64 --decode | jq -r '.exporters[] | @base64'); do
               exporterName=$(echo ${exporter} | base64 --decode | jq -r '.slug')
               cat dist/template.yml | liquid "$(echo ${exporter} | base64 --decode)" > ${subdir}/${exporterName}.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     name: Publish
+    if: github.repository_owner == 'samber'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Summary

Fixes the Publish workflow `startup_failure` that has been occurring on every push to master since May 12, 2026.

The workflow file itself did not change between the last success (May 1) and first failure (May 12), suggesting an external GitHub Actions platform change caused the startup failure.

### Changes
- Quote `ruby-version: '3.4'` as a string (YAML unquoted `3.4` could be parsed as float in some edge cases)
- Normalize indentation in the `Install liquid` step (fix 9-space indent to consistent 10-space for the `run: |` block)
- Remove trailing whitespace from `gem install liquid-cli` line

### Note
If the startup failure persists after this fix, the issue may be at the GitHub Actions infrastructure level and would need investigation via GitHub Support.
