### PR TITLE
Add Flowtriq DDoS detection alerting rules

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -4536,6 +4536,40 @@ groups:
                   May indicate routing issues or a misconfigured allowed-ips.
                   Only useful if you expect continuous traffic on all peers.
 
+      - name: Flowtriq
+        exporters:
+          - name: Embedded exporter
+            slug: embedded-exporter
+            doc_url: https://docs.flowtriq.com/integrations/prometheus
+            rules:
+              - name: Flowtriq DDoS attack detected
+                description: "Flowtriq detected a DDoS attack on {{ $value }} node(s)."
+                query: "flowtriq_nodes_under_attack > 0"
+                severity: critical
+              - name: Flowtriq node offline
+                description: "{{ $value }} Flowtriq node(s) have gone offline."
+                query: "flowtriq_nodes_offline > 0"
+                severity: warning
+                for: 5m
+              - name: Flowtriq all nodes offline
+                description: All Flowtriq nodes are offline. Network monitoring is completely unavailable.
+                query: "flowtriq_nodes_online == 0 and flowtriq_nodes_total > 0"
+                severity: critical
+                for: 2m
+              - name: Flowtriq high incident rate
+                description: "Flowtriq has detected {{ $value }} incidents in the last 24 hours."
+                query: "flowtriq_incidents_last_24h > 10"
+                severity: warning
+              - name: Flowtriq mitigation rule failed
+                description: "{{ $value }} Flowtriq mitigation rule(s) failed to apply. Attack traffic may not be filtered."
+                query: "flowtriq_mitigation_failed_rules > 0"
+                severity: critical
+              - name: Flowtriq mitigation adapter unhealthy
+                description: "Flowtriq mitigation adapter {{ $labels.adapter }} ({{ $labels.type }}) is unhealthy."
+                query: "flowtriq_mitigation_adapter_healthy == 0"
+                severity: warning
+                for: 5m
+
   - name: Storage
     services:
       - name: Ceph


### PR DESCRIPTION
Add alerting rules for [Flowtriq](https://flowtriq.com), a DDoS detection and mitigation platform with a built-in Prometheus metrics endpoint (`/api/metrics`).

**6 rules added** under "Network and security":

- **DDoS attack detected** — fires immediately when any node reports an active attack
- **Node offline** — warns when nodes drop offline for 5+ minutes
- **All nodes offline** — critical alert when the entire monitoring fleet is down
- **High incident rate** — warns when more than 10 incidents are detected in 24 hours
- **Mitigation rule failed** — critical alert when mitigation rules fail to apply
- **Mitigation adapter unhealthy** — warns when a mitigation adapter (BGP, API, etc.) is down

All queries use metrics from Flowtriq's embedded exporter. Documentation: https://docs.flowtriq.com/integrations/prometheus