### PR TITLE
added container unhealthy alert for google-cadvisor

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -517,6 +517,13 @@ groups:
                 query: '(sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) < 20'
                 severity: info
                 for: 7d
+              - name: Container Unhealthy
+                description: Container {{ $labels.name }} on {{ $labels.instance }} has been reporting an unhealthy Docker health check status for more than 5m
+                query: 'container_health_state == 0'
+                comments: |
+                  Docker-specific health check rule. 0=unhealthy, 1=healthy, -1=no health check configured.
+                severity: warning
+                for: 5m
 
       - name: Blackbox
         exporters:


### PR DESCRIPTION
Adds a new Prometheus alert rule to the google-cadvisor exporter section in _data/rules.yml that fires when a container's Docker health check reports an unhealthy status.

```
Alert: Container Unhealthy
Query: container_health_state == 0
For: 5m
Severity: warning
Description: Container {{ $labels.name }} on {{ $labels.instance }} has been reporting an unhealthy Docker health check status for more than 5m
```