### PR TITLE
fix(rules): restore default-mode MongoDB metrics for Percona exporter

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1603,12 +1603,13 @@ groups:
                 severity: warning
                 for: 2m
               - name: MongoDB replica set primary changed
-                description: MongoDB member {{ $labels.instance }} changed replica set state in the last 10 minutes, which may indicate a primary election or an unplanned failover.
-                query: "changes(mongodb_rs_myState[10m]) > 0"
+                description: MongoDB member {{ $labels.instance }} became the replica set primary in the last 10 minutes, which may indicate an election due to failover or instability.
+                query: "changes(mongodb_rs_myState[10m]) > 0 and mongodb_rs_myState == 1"
                 severity: warning
                 for: 2m
                 comments: |
                   mongodb_rs_myState (this node's replica set state) is exposed in default mode.
+                  Restricted to == 1 (PRIMARY) so the alert fires once per election, from the new primary's series, instead of on every member state transition (e.g. a secondary's restart/resync cycle).
                   Older exporters (or --compatible-mode) instead expose mongodb_mongod_replset_my_state.
               - name: MongoDB instance recently restarted
                 description: MongoDB instance {{ $labels.instance }} was restarted {{ $value }} seconds ago.

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -1561,8 +1561,11 @@ groups:
                   1m delay allows a restart without triggering an alert.
               - name: MongoDB replication lag (Percona)
                 description: Mongodb replication lag is more than 30s
-                query: 'mongodb_mongod_replset_member_replication_lag > 30'
+                query: '(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"}) / 1000 > 30'
                 severity: warning
+                comments: |
+                  mongodb_rs_members_optimeDate is exposed in default mode; its value is in milliseconds, hence the /1000 to compare seconds.
+                  Older exporters (or --compatible-mode) instead expose a ready-made lag in seconds: mongodb_mongod_replset_member_replication_lag > 30.
               - name: MongoDB replication headroom
                 description: MongoDB replication headroom is <= 0
                 query: 'sum(avg(mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
@@ -1600,14 +1603,20 @@ groups:
                 severity: warning
                 for: 2m
               - name: MongoDB replica set primary changed
-                description: Replica set {{ $labels.set }} has undergone a primary election in the last 10 minutes, which may indicate instability or an unplanned failover.
-                query: "min by (set) (changes(mongodb_mongod_replset_my_state[10m])) > 0"
+                description: MongoDB member {{ $labels.instance }} changed replica set state in the last 10 minutes, which may indicate a primary election or an unplanned failover.
+                query: "changes(mongodb_rs_myState[10m]) > 0"
                 severity: warning
                 for: 2m
+                comments: |
+                  mongodb_rs_myState (this node's replica set state) is exposed in default mode.
+                  Older exporters (or --compatible-mode) instead expose mongodb_mongod_replset_my_state.
               - name: MongoDB instance recently restarted
                 description: MongoDB instance {{ $labels.instance }} was restarted {{ $value }} seconds ago.
-                query: "mongodb_instance_uptime_seconds < 300"
+                query: "mongodb_ss_uptime < 300"
                 severity: info
+                comments: |
+                  mongodb_ss_uptime (from serverStatus.uptime) is exposed in default mode.
+                  Older exporters (or --compatible-mode) instead expose mongodb_instance_uptime_seconds.
 
           - name: dcu/mongodb_exporter
             slug: dcu-mongodb-exporter


### PR DESCRIPTION
## Summary

PR #595 and PR #596 (both merged) introduced three MongoDB rules under
the `percona/mongodb_exporter` exporter block that use metric names
which only exist when the exporter runs with `--compatible-mode` (off
by default) — the same class of bug reported and fixed for this
exporter in #290 / #291.

- **MongoDB replication lag (Percona)** — PR #595 reverted this rule
  from `mongodb_rs_members_optimeDate` (default mode, fixed by #291)
  back to `mongodb_mongod_replset_member_replication_lag`
  (`--compatible-mode` only). #342 separately fixed a sibling rule
  ("MongoDB replication headroom") and is untouched by this PR.
- **MongoDB replica set primary changed** — added by PR #596 using
  `mongodb_mongod_replset_my_state` (`--compatible-mode` only).
- **MongoDB instance recently restarted** — added by PR #596 using
  `mongodb_instance_uptime_seconds`, which belongs to the unrelated
  `dcu/mongodb_exporter` and is only a compatible-mode alias in
  Percona's exporter.

All three are switched to their default-mode equivalents
(`mongodb_rs_members_optimeDate`, `mongodb_rs_myState`,
`mongodb_ss_uptime`), verified against the exporter source
(`exporter/metrics.go`, `exporter/v1_compatibility.go` in
percona/mongodb_exporter), with a `comments:` note pointing to the
`--compatible-mode`/legacy-exporter alternative for anyone whose
deployment already relies on it.

## Test plan

- `_data/rules.yml` parses as valid YAML (verified locally).
- Cross-checked metric names, labels, and units (optimeDate is in
  milliseconds) directly against the exporter's Go source.
