### PR TITLE
refactor(rules): reorder alert rules by symptom priority within each exporter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,36 @@ Services are grouped in category. If you are not sure about the classification, 
 Field order for a rule is always `name`, `description`, `query`, `severity`, `for`, `comments` — keep new
 rules in this order even though a few legacy rules interleave `comments` earlier.
 
+### Rule ordering within an exporter
+
+Within each exporter's `rules:` list, order rules by category, not by add date or alphabetically. An
+operator scanning an exporter's page top-to-bottom should read it the way they'd triage the service
+during an incident: "is it up?" before "is it slow?" before "is it running low on something?" before
+"is this just an FYI?". The categories, in order:
+
+1. **Availability** — the instance/service/cluster is down or unreachable: liveness checks (see
+   "Service-down pattern" below), `absent()` checks, quorum/leader loss, replication broken/disconnected,
+   election/failover/split-brain. This is what a human needs to know first: is there anyone home.
+2. **Resource saturation (USE: Utilization / Saturation / Errors)** — CPU, memory, disk/filesystem,
+   network, file descriptors, connection pools. Group rules by resource (all CPU rules together, then all
+   memory rules, then all disk rules, etc.) rather than interleaving resources — this keeps a hard
+   threshold and its predictive/soft-threshold sibling adjacent (e.g. "disk almost full" next to "disk
+   predicted to fill within 24h"), instead of separated by an unrelated resource's alerts.
+3. **Performance and errors (RED: Rate / Errors / Duration)** — latency, error rate, timeouts, queue/lag
+   backlog, failed jobs, retries, GC pauses, crash-loop/restart-count alerts. The service is up and
+   resources look fine, but symptoms indicate degraded behavior.
+4. **Capacity and trend** — non-resource capacity concerns that don't fit under a specific USE resource:
+   backups/snapshots missing or outdated, quota/license approaching limits, long-term growth trends.
+5. **Info, security, and config** — config reload failures, certificate/TLS expiry, auth failures,
+   security notifications, config-change detections. Usually `severity: info` (see "Severity levels"
+   below), read last because they're awareness-only, not triage priorities.
+
+Within the same category, order by severity (`critical`, then `warning`, then `info`); ties within the
+same category and severity keep their existing relative order rather than being reshuffled arbitrarily.
+
+This convention governs new PRs and rule reorderings; it does not by itself justify rewriting existing
+descriptions, queries, or thresholds — reordering is a pure permutation of the `rules:` list.
+
 ## YAML Authoring Conventions
 
 These are patterns observed consistently across the ~940 existing rules in `_data/rules.yml` but not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,6 @@ Use the category name as written above (`Availability`, `Resource saturation (US
 errors (RED)`, `Capacity and trend`, `Info, security, and config`). Omit the header for a category that
 has no rules in a given exporter.
 
-This convention governs new PRs and rule reorderings; it does not by itself justify rewriting existing
-descriptions, queries, or thresholds — reordering is a pure permutation of the `rules:` list.
-
 ## YAML Authoring Conventions
 
 These are patterns observed consistently across the ~940 existing rules in `_data/rules.yml` but not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,21 @@ during an incident: "is it up?" before "is it slow?" before "is it running low o
 Within the same category, order by severity (`critical`, then `warning`, then `info`); ties within the
 same category and severity keep their existing relative order rather than being reshuffled arbitrarily.
 
+Mark each category boundary with a plain `#` comment (see "Comments" below — this is the source-only
+scope, stripped at render time, not the rule-level `comments:` field) directly above the first rule of
+that category, with no blank line before it:
+
+```yaml
+              #
+              # {Category name}
+              #
+              - name: "<first rule of this category>"
+```
+
+Use the category name as written above (`Availability`, `Resource saturation (USE)`, `Performance and
+errors (RED)`, `Capacity and trend`, `Info, security, and config`). Omit the header for a category that
+has no rules in a given exporter.
+
 This convention governs new PRs and rule reorderings; it does not by itself justify rewriting existing
 descriptions, queries, or thresholds — reordering is a pure permutation of the `rules:` list.
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -15,10 +15,9 @@ groups:
         exporters:
           - slug: embedded-exporter
             rules:
-              - name: Prometheus job missing
-                description: A Prometheus job has disappeared
-                query: 'absent(up{job="prometheus"})'
-                severity: warning
+              #
+              # Availability
+              #
               - name: Prometheus target missing
                 description: A Prometheus target has disappeared. An exporter might be crashed.
                 query: "up == 0 unless on(job) (sum by (job) (up) == 0)"
@@ -37,37 +36,33 @@ groups:
                 query: "sum by (instance, job) ((up == 0) * on (instance) group_left(__name__) (node_time_seconds - node_boot_time_seconds > 600))"
                 severity: critical
                 for: 1m
-              - name: Prometheus configuration reload failure
-                description: Prometheus configuration reload error
-                query: "prometheus_config_last_reload_successful != 1"
-                severity: warning
-              - name: Prometheus too many restarts
-                description: Prometheus has restarted more than twice in the last 15 minutes. It might be crashlooping.
-                query: 'changes(process_start_time_seconds{job=~"prometheus|pushgateway|alertmanager"}[15m]) > 2'
+              - name: Prometheus not connected to alertmanager
+                description: Prometheus cannot connect the alertmanager
+                query: "prometheus_notifications_alertmanagers_discovered < 1"
+                severity: critical
+              - name: Prometheus job missing
+                description: A Prometheus job has disappeared
+                query: 'absent(up{job="prometheus"})'
                 severity: warning
               - name: Prometheus AlertManager job missing
                 description: A Prometheus AlertManager job has disappeared
                 query: 'absent(up{job="alertmanager"})'
                 severity: warning
-              - name: Prometheus AlertManager configuration reload failure
-                description: AlertManager configuration reload error
-                query: "alertmanager_config_last_reload_successful != 1"
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Prometheus target scrape out of order
+                description: Prometheus is dropping samples because their timestamps arrive out of order ({{ $value }} samples in the last 5 minutes), indicating a misbehaving target or clock skew.
+                query: "increase(prometheus_target_scrapes_sample_out_of_order_total[5m]) > 3"
                 severity: warning
-              - name: Prometheus AlertManager config not synced
-                description: Configurations of AlertManager cluster instances are out of sync
-                query: 'count(count_values("config_hash", alertmanager_config_hash)) > 1'
-                severity: warning
-                for: 20m
-                comments: |
-                  for: 20m tolerates the time a rolling config change takes to propagate across the
-                  Alertmanager cluster, avoiding false positives mid-deploy.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Prometheus AlertManager E2E dead man switch
                 description: "Prometheus DeadManSwitch is an always-firing alert. It's used as an end-to-end test of Prometheus through the Alertmanager."
                 query: "vector(1)"
-                severity: critical
-              - name: Prometheus not connected to alertmanager
-                description: Prometheus cannot connect the alertmanager
-                query: "prometheus_notifications_alertmanagers_discovered < 1"
                 severity: critical
               - name: Prometheus rule evaluation failures
                 description: "Prometheus encountered {{ $value }} rule evaluation failures, leading to potentially ignored alerts."
@@ -77,15 +72,6 @@ groups:
                 description: "Prometheus encountered {{ $value }} template text expansion failures"
                 query: "increase(prometheus_template_text_expansion_failures_total[3m]) > 0"
                 severity: critical
-              - name: Prometheus rule evaluation slow
-                description: "Prometheus rule evaluation took more time than the scheduled interval. It indicates a slower storage backend access or too complex query."
-                query: "prometheus_rule_group_last_duration_seconds > prometheus_rule_group_interval_seconds"
-                severity: warning
-                for: 5m
-              - name: Prometheus notifications backlog
-                description: The Prometheus notification queue has not been empty for 10 minutes
-                query: "min_over_time(prometheus_notifications_queue_length[10m]) > 0"
-                severity: warning
               - name: Prometheus AlertManager notification failing
                 description: "Alertmanager is failing to send {{ $value | humanizePercentage }} of notifications"
                 query: "(rate(alertmanager_notifications_failed_total[5m]) / ignoring(reason) group_left rate(alertmanager_notifications_total[5m])) > 0.01 and ignoring(reason) rate(alertmanager_notifications_total[5m]) > 0"
@@ -94,20 +80,6 @@ groups:
                 description: Prometheus has no target in service discovery
                 query: "prometheus_sd_discovered_targets == 0"
                 severity: critical
-              - name: Prometheus target scraping slow
-                description: Prometheus is scraping exporters slowly since it exceeded the requested interval time. Your Prometheus server is under-provisioned.
-                query: 'prometheus_target_interval_length_seconds{quantile="0.9"} / on (interval, instance, job) prometheus_target_interval_length_seconds{quantile="0.5"} > 1.05'
-                severity: warning
-                for: 5m
-              - name: Prometheus large scrape
-                description: "Prometheus has many scrapes that exceed the sample limit ({{ $value }} scrapes)"
-                query: "increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m]) > 10"
-                severity: warning
-                for: 5m
-              - name: Prometheus target scrape duplicate
-                description: "Prometheus has many samples rejected due to duplicate timestamps but different values ({{ $value }} samples)"
-                query: "increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 3"
-                severity: warning
               - name: Prometheus TSDB checkpoint creation failures
                 description: "Prometheus encountered {{ $value }} checkpoint creation failures"
                 query: "increase(prometheus_tsdb_checkpoint_creations_failed_total[1m]) > 0"
@@ -138,15 +110,6 @@ groups:
                 description: "Prometheus encountered {{ $value }} TSDB WAL truncation failures"
                 query: "increase(prometheus_tsdb_wal_truncations_failed_total[1m]) > 0"
                 severity: critical
-              - name: Prometheus timeseries cardinality
-                description: 'The "{{ $labels.name }}" timeseries cardinality is getting very high: {{ $value }}'
-                query: 'label_replace(count by(__name__) ({__name__=~".+"}), "name", "$1", "__name__", "(.+)") > 10000'
-                severity: warning
-              - name: Prometheus error sending alerts to AlertManager
-                description: Prometheus is failing to send {{ $value | humanize }}% of alerts to a specific Alertmanager instance, meaning some alerts may not be delivered.
-                query: "(rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m])) * 100 > 1"
-                severity: warning
-                for: 15m
               - name: Prometheus error sending alerts to any AlertManager
                 description: Prometheus is failing to send at least {{ $value | humanize }}% of alerts to every configured Alertmanager, meaning alert delivery is broadly impaired.
                 query: "min without (alertmanager) (rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m])) * 100 > 3"
@@ -157,10 +120,47 @@ groups:
                 query: "sum without(type) (rate(prometheus_tsdb_head_samples_appended_total[5m])) <= 0 and (sum without(scrape_job) (prometheus_target_metadata_cache_entries) > 0 or sum without(rule_group) (prometheus_rule_group_rules) > 0)"
                 severity: critical
                 for: 10m
-              - name: Prometheus target scrape out of order
-                description: Prometheus is dropping samples because their timestamps arrive out of order ({{ $value }} samples in the last 5 minutes), indicating a misbehaving target or clock skew.
-                query: "increase(prometheus_target_scrapes_sample_out_of_order_total[5m]) > 3"
+              - name: Prometheus target sync failure
+                description: "{{ $value }} Prometheus targets failed to sync because invalid scrape configuration was supplied, meaning those targets are not being scraped."
+                query: "increase(prometheus_target_sync_failed_total[10m]) > 0"
+                severity: critical
+                for: 5m
+              - name: Prometheus too many restarts
+                description: Prometheus has restarted more than twice in the last 15 minutes. It might be crashlooping.
+                query: 'changes(process_start_time_seconds{job=~"prometheus|pushgateway|alertmanager"}[15m]) > 2'
                 severity: warning
+              - name: Prometheus rule evaluation slow
+                description: "Prometheus rule evaluation took more time than the scheduled interval. It indicates a slower storage backend access or too complex query."
+                query: "prometheus_rule_group_last_duration_seconds > prometheus_rule_group_interval_seconds"
+                severity: warning
+                for: 5m
+              - name: Prometheus notifications backlog
+                description: The Prometheus notification queue has not been empty for 10 minutes
+                query: "min_over_time(prometheus_notifications_queue_length[10m]) > 0"
+                severity: warning
+              - name: Prometheus target scraping slow
+                description: Prometheus is scraping exporters slowly since it exceeded the requested interval time. Your Prometheus server is under-provisioned.
+                query: 'prometheus_target_interval_length_seconds{quantile="0.9"} / on (interval, instance, job) prometheus_target_interval_length_seconds{quantile="0.5"} > 1.05'
+                severity: warning
+                for: 5m
+              - name: Prometheus large scrape
+                description: "Prometheus has many scrapes that exceed the sample limit ({{ $value }} scrapes)"
+                query: "increase(prometheus_target_scrapes_exceeded_sample_limit_total[10m]) > 10"
+                severity: warning
+                for: 5m
+              - name: Prometheus target scrape duplicate
+                description: "Prometheus has many samples rejected due to duplicate timestamps but different values ({{ $value }} samples)"
+                query: "increase(prometheus_target_scrapes_sample_duplicate_timestamp_total[5m]) > 3"
+                severity: warning
+              - name: Prometheus timeseries cardinality
+                description: 'The "{{ $labels.name }}" timeseries cardinality is getting very high: {{ $value }}'
+                query: 'label_replace(count by(__name__) ({__name__=~".+"}), "name", "$1", "__name__", "(.+)") > 10000'
+                severity: warning
+              - name: Prometheus error sending alerts to AlertManager
+                description: Prometheus is failing to send {{ $value | humanize }}% of alerts to a specific Alertmanager instance, meaning some alerts may not be delivered.
+                query: "(rate(prometheus_notifications_errors_total[5m]) / rate(prometheus_notifications_sent_total[5m])) * 100 > 1"
+                severity: warning
+                for: 15m
               - name: Prometheus service discovery refresh failure
                 description: Prometheus failed to refresh service discovery targets using mechanism {{ $labels.mechanism }}, meaning target lists may become stale.
                 query: "increase(prometheus_sd_refresh_failures_total[10m]) > 0"
@@ -171,16 +171,31 @@ groups:
                 query: "increase(prometheus_rule_group_iterations_missed_total[5m]) > 0"
                 severity: warning
                 for: 5m
-              - name: Prometheus target sync failure
-                description: "{{ $value }} Prometheus targets failed to sync because invalid scrape configuration was supplied, meaning those targets are not being scraped."
-                query: "increase(prometheus_target_sync_failed_total[10m]) > 0"
-                severity: critical
-                for: 5m
               - name: Prometheus high query load
                 description: Prometheus query engine has less than 20% available capacity for concurrent queries, meaning it is approaching its configured concurrency limit and may start rejecting queries.
                 query: "prometheus_engine_queries / prometheus_engine_queries_concurrent_max > 0.8"
                 severity: warning
                 for: 5m
+
+              #
+              # Info, security, and config
+              #
+              - name: Prometheus configuration reload failure
+                description: Prometheus configuration reload error
+                query: "prometheus_config_last_reload_successful != 1"
+                severity: warning
+              - name: Prometheus AlertManager configuration reload failure
+                description: AlertManager configuration reload error
+                query: "alertmanager_config_last_reload_successful != 1"
+                severity: warning
+              - name: Prometheus AlertManager config not synced
+                description: Configurations of AlertManager cluster instances are out of sync
+                query: 'count(count_values("config_hash", alertmanager_config_hash)) > 1'
+                severity: warning
+                for: 20m
+                comments: |
+                  for: 20m tolerates the time a rolling config change takes to propagate across the
+                  Alertmanager cluster, avoiding false positives mid-deploy.
 
       - name: Host and hardware
         logo: /images/services/host-and-hardware.svg
@@ -189,6 +204,34 @@ groups:
             slug: node-exporter
             doc_url: https://github.com/prometheus/node_exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Host high CPU load
+                description: CPU load is > 80%
+                query: '1 - (avg without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) > .80'
+                severity: warning
+                for: 10m
+              - name: Host CPU steal noisy neighbor
+                description: CPU steal is > 10%. A noisy neighbor is killing VM performances or a spot instance may be out of credit.
+                query: 'avg without (cpu) (rate(node_cpu_seconds_total{mode="steal"}[5m])) * 100 > 10'
+                severity: warning
+              - name: Host CPU high iowait
+                description: CPU iowait > 10%. Your CPU is idling waiting for storage to respond.
+                query: 'avg without (cpu) (rate(node_cpu_seconds_total{mode="iowait"}[5m])) > .10'
+                severity: warning
+              - name: Host CPU load saturation
+                description: Load average (1m) per CPU core on {{ $labels.instance }} is more than double the number of idle cores, meaning processes are queued waiting for CPU even if raw CPU utilization looks normal.
+                query: 'node_load1 / count without (cpu, mode) (node_cpu_seconds_total{mode="idle"}) > 2'
+                severity: warning
+                for: 10m
+              - name: Host CPU is underutilized
+                description: "CPU load has been < 20% for 1 week. Consider reducing the number of CPUs."
+                query: '(min without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[1h]))) > 0.8'
+                severity: info
+                for: 1w
+                comments: |
+                  You may want to increase the alert manager 'repeat_interval' for this type of alert to daily or weekly
               - name: Host out of memory
                 description: Node memory is filling up (< 10% left)
                 query: "(node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < .10)"
@@ -208,31 +251,10 @@ groups:
                 severity: info
                 comments: |
                   You may want to increase the alert manager 'repeat_interval' for this type of alert to daily or weekly
-              - name: Host unusual network throughput in
-                description: Host receive bandwidth is high (>80%).
-                query: "((rate(node_network_receive_bytes_total[5m]) / node_network_speed_bytes) > .80) and node_network_speed_bytes > 0"
-                severity: warning
-              - name: Host unusual network throughput out
-                description: Host transmit bandwidth is high (>80%)
-                query: "((rate(node_network_transmit_bytes_total[5m]) / node_network_speed_bytes) > .80) and node_network_speed_bytes > 0"
-                severity: warning
-              - name: Host disk IO utilization high
-                description: Disk utilization is high (> 80%)
-                query: "(rate(node_disk_io_time_seconds_total[5m]) > .80)"
-                severity: warning
               - name: Host out of disk space
                 description: Disk is almost full (< 10% left)
                 query: '(node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} / node_filesystem_size_bytes < .10 and on (instance, device, mountpoint) node_filesystem_readonly == 0)'
                 severity: critical
-                comments: |
-                  Please add ignored mountpoints in node_exporter parameters like
-                  "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)".
-                  Same rule using "node_filesystem_free_bytes" will fire when disk fills for non-root users.
-                for: 2m
-              - name: Host disk may fill in 24 hours
-                description: Filesystem will likely run out of space within the next 24 hours.
-                query: 'predict_linear(node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"}[3h], 86400) <= 0 and node_filesystem_avail_bytes > 0 and node_filesystem_readonly == 0'
-                severity: warning
                 comments: |
                   Please add ignored mountpoints in node_exporter parameters like
                   "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)".
@@ -243,71 +265,60 @@ groups:
                 query: "(node_filesystem_files_free / node_filesystem_files < .10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0) and node_filesystem_files > 0"
                 severity: critical
                 for: 2m
-              - name: Host filesystem device error
-                description: "Error stat-ing the {{ $labels.mountpoint }} filesystem"
-                query: 'node_filesystem_device_error{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} == 1'
-                severity: critical
+              - name: Host disk IO utilization high
+                description: Disk utilization is high (> 80%)
+                query: "(rate(node_disk_io_time_seconds_total[5m]) > .80)"
+                severity: warning
+              - name: Host disk may fill in 24 hours
+                description: Filesystem will likely run out of space within the next 24 hours.
+                query: 'predict_linear(node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"}[3h], 86400) <= 0 and node_filesystem_avail_bytes > 0 and node_filesystem_readonly == 0'
+                severity: warning
+                comments: |
+                  Please add ignored mountpoints in node_exporter parameters like
+                  "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/)".
+                  Same rule using "node_filesystem_free_bytes" will fire when disk fills for non-root users.
                 for: 2m
               - name: Host inodes may fill in 24 hours
                 description: Filesystem will likely run out of inodes within the next 24 hours at current write rate
                 query: 'predict_linear(node_filesystem_files_free{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"}[1h], 86400) <= 0 and node_filesystem_files_free > 0 and node_filesystem_readonly == 0'
                 severity: warning
                 for: 2m
-              - name: Host unusual disk read latency
-                description: Disk latency is growing (read operations > 100ms)
-                query: "(rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0)"
-                severity: warning
-                for: 2m
-              - name: Host unusual disk write latency
-                description: Disk latency is growing (write operations > 100ms)
-                query: "(rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 0.1 and rate(node_disk_writes_completed_total[1m]) > 0)"
-                severity: warning
-                for: 2m
-              - name: Host high CPU load
-                description: CPU load is > 80%
-                query: '1 - (avg without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) > .80'
-                severity: warning
-                for: 10m
-              - name: Host CPU is underutilized
-                description: "CPU load has been < 20% for 1 week. Consider reducing the number of CPUs."
-                query: '(min without (cpu) (rate(node_cpu_seconds_total{mode="idle"}[1h]))) > 0.8'
-                severity: info
-                for: 1w
-                comments: |
-                  You may want to increase the alert manager 'repeat_interval' for this type of alert to daily or weekly
-              - name: Host CPU steal noisy neighbor
-                description: CPU steal is > 10%. A noisy neighbor is killing VM performances or a spot instance may be out of credit.
-                query: 'avg without (cpu) (rate(node_cpu_seconds_total{mode="steal"}[5m])) * 100 > 10'
-                severity: warning
-              - name: Host CPU high iowait
-                description: CPU iowait > 10%. Your CPU is idling waiting for storage to respond.
-                query: 'avg without (cpu) (rate(node_cpu_seconds_total{mode="iowait"}[5m])) > .10'
-                severity: warning
               - name: Host unusual disk IO
                 description: "Disk usage >80%. Check storage for issues or increase IOPS capabilities."
                 query: "rate(node_disk_io_time_seconds_total[5m]) > 0.8"
                 severity: warning
                 for: 5m
-              - name: Host context switching high
-                description: Context switching is growing on the node (twice the daily average during the last 15m)
-                query: '(rate(node_context_switches_total[15m])/count without(mode,cpu) (node_cpu_seconds_total{mode="idle"})) / (rate(node_context_switches_total[1d])/count without(mode,cpu) (node_cpu_seconds_total{mode="idle"})) > 2 and rate(node_context_switches_total[1d]) > 0'
+              - name: Host disk IO saturation
+                description: Weighted disk I/O time on {{ $labels.instance }} indicates a growing request queue depth (similar to iostat's aqu-sz), a distinct saturation symptom from raw disk busy-time utilization.
+                query: "rate(node_disk_io_time_weighted_seconds_total[5m]) > 10"
                 severity: warning
-                comments: |
-                  x2 context switches is an arbitrary number.
-                  The alert threshold depends on the nature of the application.
-                  Please read: https://github.com/samber/awesome-prometheus-alerts/issues/58
+                for: 5m
+              - name: Host unusual network throughput in
+                description: Host receive bandwidth is high (>80%).
+                query: "((rate(node_network_receive_bytes_total[5m]) / node_network_speed_bytes) > .80) and node_network_speed_bytes > 0"
+                severity: warning
+              - name: Host unusual network throughput out
+                description: Host transmit bandwidth is high (>80%)
+                query: "((rate(node_network_transmit_bytes_total[5m]) / node_network_speed_bytes) > .80) and node_network_speed_bytes > 0"
+                severity: warning
+              - name: Host Network Bond Degraded
+                description: 'Bond "{{ $labels.device }}" degraded on "{{ $labels.instance }}".'
+                query: "((node_bonding_active - node_bonding_slaves) != 0)"
+                severity: warning
+                for: 2m
+              - name: Host file descriptors limit critical
+                description: Kernel file descriptor usage on {{ $labels.instance }} is above 90% of the configured maximum, and file descriptor exhaustion is imminent.
+                query: "node_filefd_allocated * 100 / node_filefd_maximum > 90"
+                severity: critical
+                for: 2m
               - name: Host swap is filling up
                 description: Swap is filling up (>80%)
                 query: "((1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80) and node_memory_SwapTotal_bytes > 0"
                 severity: warning
                 for: 2m
-              - name: Host systemd service crashed
-                description: "systemd service {{ $labels.name }} crashed"
-                query: '(node_systemd_unit_state{state="failed"} == 1)'
-                severity: warning
-              - name: Host physical component too hot
-                description: "Physical hardware component too hot"
-                query: "node_hwmon_temp_celsius > node_hwmon_temp_max_celsius"
+              - name: Host file descriptors limit warning
+                description: Kernel file descriptor usage on {{ $labels.instance }} is above 70% of the configured maximum, risking failures for daemons or the kernel when they can no longer open new files.
+                query: "node_filefd_allocated * 100 / node_filefd_maximum > 70"
                 severity: warning
                 for: 5m
               - name: Host node overtemperature alarm
@@ -323,30 +334,63 @@ groups:
                   query would still report a temporary drive deficit; adjust for a "for" duration if that
                   causes noisy alerts on your setup.
                 severity: critical
+              - name: Host context switching high
+                description: Context switching is growing on the node (twice the daily average during the last 15m)
+                query: '(rate(node_context_switches_total[15m])/count without(mode,cpu) (node_cpu_seconds_total{mode="idle"})) / (rate(node_context_switches_total[1d])/count without(mode,cpu) (node_cpu_seconds_total{mode="idle"})) > 2 and rate(node_context_switches_total[1d]) > 0'
+                severity: warning
+                comments: |
+                  x2 context switches is an arbitrary number.
+                  The alert threshold depends on the nature of the application.
+                  Please read: https://github.com/samber/awesome-prometheus-alerts/issues/58
+              - name: Host physical component too hot
+                description: "Physical hardware component too hot"
+                query: "node_hwmon_temp_celsius > node_hwmon_temp_max_celsius"
+                severity: warning
+                for: 5m
+              - name: Host clock skew
+                description: "Clock skew detected. Clock is out of sync. Ensure NTP is configured correctly on this host."
+                query: "((node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0))"
+                severity: warning
+                for: 10m
+              - name: Host clock not synchronising
+                description: "Clock not synchronising. Ensure NTP is configured on this host."
+                query: "(min_over_time(node_timex_sync_status[3m]) == 0 and node_timex_maxerror_seconds >= 16)"
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Host filesystem device error
+                description: "Error stat-ing the {{ $labels.mountpoint }} filesystem"
+                query: 'node_filesystem_device_error{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} == 1'
+                severity: critical
+                for: 2m
+              - name: Host unusual disk read latency
+                description: Disk latency is growing (read operations > 100ms)
+                query: "(rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0)"
+                severity: warning
+                for: 2m
+              - name: Host unusual disk write latency
+                description: Disk latency is growing (write operations > 100ms)
+                query: "(rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 0.1 and rate(node_disk_writes_completed_total[1m]) > 0)"
+                severity: warning
+                for: 2m
+              - name: Host systemd service crashed
+                description: "systemd service {{ $labels.name }} crashed"
+                query: '(node_systemd_unit_state{state="failed"} == 1)'
+                severity: warning
               - name: Host software RAID disk failure
                 description: "MD RAID array {{ $labels.device }} on {{ $labels.instance }} needs attention."
                 query: '(node_md_disks{state="failed"} > 0)'
                 severity: warning
                 for: 2m
-              - name: Host kernel version deviations
-                description: Kernel version for {{ $labels.instance }} has changed.
-                query: "changes(node_uname_info[1h]) > 0"
-                severity: info
-              # node_exporter pipes every /proc/vmstat field through one generic path as Untyped, so the
-              # declared type carries no semantics here. The kernel value is increment-only since boot
-              # (vm_event_item, mutated only by raw_cpu_inc), i.e. a counter that resets on reboot only.
-              # increase() corrects that reset; delta() would swing negative across it — which is exactly
-              # the reboot that an OOM storm tends to end in.
               - name: Host OOM kill detected
                 description: OOM kill detected
                 query: "(increase(node_vmstat_oom_kill[30m]) > 0)"
                 severity: warning
                 comments: |
                   When a machine runs out of memory, the node exporter can become unresponsive for several minutes. Even if the system takes 15–20 minutes to recover, the alert should still trigger.
-              - name: Host EDAC Correctable Errors detected
-                description: 'Host {{ $labels.instance }} has had {{ printf "%.0f" $value }} correctable memory errors reported by EDAC in the last 1 minute.'
-                query: "(increase(node_edac_correctable_errors_total[1m]) > 0)"
-                severity: info
               - name: Host EDAC Uncorrectable Errors detected
                 description: 'Host {{ $labels.instance }} has had {{ printf "%.0f" $value }} uncorrectable memory errors reported by EDAC.'
                 query: "(node_edac_uncorrectable_errors_total > 0)"
@@ -361,24 +405,9 @@ groups:
                 query: "(rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01) and rate(node_network_transmit_packets_total[2m]) > 0"
                 severity: warning
                 for: 2m
-              - name: Host Network Bond Degraded
-                description: 'Bond "{{ $labels.device }}" degraded on "{{ $labels.instance }}".'
-                query: "((node_bonding_active - node_bonding_slaves) != 0)"
-                severity: warning
-                for: 2m
               - name: Host conntrack limit
                 description: "The number of conntrack is approaching limit"
                 query: "(node_nf_conntrack_entries / node_nf_conntrack_entries_limit > 0.8) and node_nf_conntrack_entries_limit > 0"
-                severity: warning
-                for: 5m
-              - name: Host clock skew
-                description: "Clock skew detected. Clock is out of sync. Ensure NTP is configured correctly on this host."
-                query: "((node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0))"
-                severity: warning
-                for: 10m
-              - name: Host clock not synchronising
-                description: "Clock not synchronising. Ensure NTP is configured on this host."
-                query: "(min_over_time(node_timex_sync_status[3m]) == 0 and node_timex_maxerror_seconds >= 16)"
                 severity: warning
                 for: 5m
               - name: Host textfile collector scrape error
@@ -386,30 +415,27 @@ groups:
                 query: "node_textfile_scrape_error == 1"
                 severity: warning
                 for: 5m
-              - name: Host file descriptors limit warning
-                description: Kernel file descriptor usage on {{ $labels.instance }} is above 70% of the configured maximum, risking failures for daemons or the kernel when they can no longer open new files.
-                query: "node_filefd_allocated * 100 / node_filefd_maximum > 70"
-                severity: warning
-                for: 5m
-              - name: Host file descriptors limit critical
-                description: Kernel file descriptor usage on {{ $labels.instance }} is above 90% of the configured maximum, and file descriptor exhaustion is imminent.
-                query: "node_filefd_allocated * 100 / node_filefd_maximum > 90"
-                severity: critical
-                for: 2m
-              - name: Host CPU load saturation
-                description: Load average (1m) per CPU core on {{ $labels.instance }} is more than double the number of idle cores, meaning processes are queued waiting for CPU even if raw CPU utilization looks normal.
-                query: 'node_load1 / count without (cpu, mode) (node_cpu_seconds_total{mode="idle"}) > 2'
-                severity: warning
-                for: 10m
-              - name: Host disk IO saturation
-                description: Weighted disk I/O time on {{ $labels.instance }} indicates a growing request queue depth (similar to iostat's aqu-sz), a distinct saturation symptom from raw disk busy-time utilization.
-                query: "rate(node_disk_io_time_weighted_seconds_total[5m]) > 10"
-                severity: warning
-                for: 5m
               - name: Host systemd service crash looping
                 description: Systemd service {{ $labels.name }} on {{ $labels.instance }} has restarted more than twice in the last 5 minutes, indicating a crash loop that a simple 'failed' state check would miss because the service keeps restarting successfully.
                 query: "increase(node_systemd_service_restart_total[5m]) > 2"
                 severity: warning
+              - name: Host EDAC Correctable Errors detected
+                description: 'Host {{ $labels.instance }} has had {{ printf "%.0f" $value }} correctable memory errors reported by EDAC in the last 1 minute.'
+                query: "(increase(node_edac_correctable_errors_total[1m]) > 0)"
+                severity: info
+
+              #
+              # Info, security, and config
+              #
+              - name: Host kernel version deviations
+                description: Kernel version for {{ $labels.instance }} has changed.
+                query: "changes(node_uname_info[1h]) > 0"
+                severity: info
+              # node_exporter pipes every /proc/vmstat field through one generic path as Untyped, so the
+              # declared type carries no semantics here. The kernel value is increment-only since boot
+              # (vm_event_item, mutated only by raw_cpu_inc), i.e. a counter that resets on reboot only.
+              # increase() corrects that reset; delta() would swing negative across it — which is exactly
+              # the reboot that an OOM storm tends to end in.
 
       - name: S.M.A.R.T Device Monitoring
         logo: /images/services/s-m-a-r-t-device-monitoring.svg
@@ -418,10 +444,13 @@ groups:
             slug: smartctl-exporter
             doc_url: https://github.com/prometheus-community/smartctl_exporter
             rules:
-              - name: SMART device temperature warning
-                description: Device temperature warning on {{ $labels.instance }} drive {{ $labels.device }} over 60°C
-                query: '(avg_over_time(smartctl_device_temperature{temperature_type="current"} [5m]) unless on (instance, device) smartctl_device_temperature{temperature_type="drive_trip"}) > 60'
-                severity: warning
+              #
+              # Resource saturation (USE)
+              #
+              - name: SMART critical warning
+                description: Disk controller has critical warning on {{ $labels.instance }} drive {{ $labels.device }}
+                query: "smartctl_device_critical_warning > 0"
+                severity: critical
               - name: SMART device temperature critical
                 description: Device temperature critical on {{ $labels.instance }} drive {{ $labels.device }} over 70°C
                 query: '(max_over_time(smartctl_device_temperature{temperature_type="current"} [5m]) unless on (instance, device) smartctl_device_temperature{temperature_type="drive_trip"}) > 70'
@@ -430,17 +459,21 @@ groups:
                 description: Device temperature over trip value on {{ $labels.instance }} drive {{ $labels.device }}
                 query: 'max_over_time(smartctl_device_temperature{temperature_type="current"} [10m]) >= on(device, instance) smartctl_device_temperature{temperature_type="drive_trip"}'
                 severity: critical
+              - name: SMART device temperature warning
+                description: Device temperature warning on {{ $labels.instance }} drive {{ $labels.device }} over 60°C
+                query: '(avg_over_time(smartctl_device_temperature{temperature_type="current"} [5m]) unless on (instance, device) smartctl_device_temperature{temperature_type="drive_trip"}) > 60'
+                severity: warning
               - name: SMART device temperature nearing trip value
                 description: Device temperature at 80% of trip value on {{ $labels.instance }} drive {{ $labels.device }}
                 query: 'max_over_time(smartctl_device_temperature{temperature_type="current"} [10m]) >= on(device, instance) (smartctl_device_temperature{temperature_type="drive_trip"} * .80)'
                 severity: warning
+
+              #
+              # Performance and errors (RED)
+              #
               - name: SMART status
                 description: Device has a SMART status failure on {{ $labels.instance }} drive {{ $labels.device }}
                 query: "smartctl_device_smart_status != 1"
-                severity: critical
-              - name: SMART critical warning
-                description: Disk controller has critical warning on {{ $labels.instance }} drive {{ $labels.device }}
-                query: "smartctl_device_critical_warning > 0"
                 severity: critical
               - name: SMART media errors
                 description: Disk controller detected media errors on {{ $labels.instance }} drive {{ $labels.device }}
@@ -462,6 +495,13 @@ groups:
             slug: ipmi-exporter
             doc_url: https://github.com/prometheus-community/ipmi_exporter
             rules:
+              #
+              # Availability
+              #
+              - name: IPMI chassis power off
+                description: "IPMI reports chassis power is off on {{ $labels.instance }}. The server may have shut down unexpectedly."
+                query: 'ipmi_chassis_power_state == 0'
+                severity: critical
               - name: IPMI collector down
                 description: "IPMI collector {{ $labels.collector }} on {{ $labels.instance }} failed to scrape sensor data. Check FreeIPMI tools and BMC connectivity."
                 query: 'ipmi_up == 0'
@@ -469,22 +509,21 @@ groups:
                 for: 5m
                 comments: |
                   The ipmi_up metric is per-collector. A value of 0 means the collector could not retrieve data from the BMC.
-              - name: IPMI temperature sensor warning
-                description: "IPMI temperature sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
-                query: 'ipmi_temperature_state == 1'
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: IPMI SEL almost full
+                description: "IPMI System Event Log on {{ $labels.instance }} has only {{ printf \"%.0f\" $value }} bytes free. Clear the SEL to prevent loss of new events."
+                query: 'ipmi_sel_free_space_bytes < 512'
                 severity: warning
                 for: 5m
                 comments: |
-                  State values: 0=nominal, 1=warning, 2=critical. Thresholds are defined in the BMC firmware.
+                  SEL storage is typically very limited (e.g., 16KB). When full, new events may be dropped.
               - name: IPMI temperature sensor critical
                 description: "IPMI temperature sensor {{ $labels.name }} on {{ $labels.instance }} is in critical state. Immediate attention required to prevent hardware damage."
                 query: 'ipmi_temperature_state == 2'
                 severity: critical
-              - name: IPMI fan speed sensor warning
-                description: "IPMI fan sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
-                query: 'ipmi_fan_speed_state == 1'
-                severity: warning
-                for: 5m
               - name: IPMI fan speed sensor critical
                 description: "IPMI fan sensor {{ $labels.name }} on {{ $labels.instance }} is in critical state. A fan may have failed."
                 query: 'ipmi_fan_speed_state == 2'
@@ -494,29 +533,14 @@ groups:
                 query: 'ipmi_fan_speed_rpm == 0'
                 severity: critical
                 for: 5m
-              - name: IPMI voltage sensor warning
-                description: "IPMI voltage sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
-                query: 'ipmi_voltage_state == 1'
-                severity: warning
-                for: 5m
               - name: IPMI voltage sensor critical
                 description: "IPMI voltage sensor {{ $labels.name }} on {{ $labels.instance }} is in critical state. Power supply or motherboard issue possible."
                 query: 'ipmi_voltage_state == 2'
                 severity: critical
-              - name: IPMI current sensor warning
-                description: "IPMI current sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
-                query: 'ipmi_current_state == 1'
-                severity: warning
-                for: 5m
               - name: IPMI current sensor critical
                 description: "IPMI current sensor {{ $labels.name }} on {{ $labels.instance }} is in critical state."
                 query: 'ipmi_current_state == 2'
                 severity: critical
-              - name: IPMI power sensor warning
-                description: "IPMI power sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
-                query: 'ipmi_power_state == 1'
-                severity: warning
-                for: 5m
               - name: IPMI power sensor critical
                 description: "IPMI power sensor {{ $labels.name }} on {{ $labels.instance }} is in critical state."
                 query: 'ipmi_power_state == 2'
@@ -528,10 +552,6 @@ groups:
                 for: 5m
                 comments: |
                   Catches any sensor type not covered by the specific temperature/fan/voltage/current/power alerts.
-              - name: IPMI chassis power off
-                description: "IPMI reports chassis power is off on {{ $labels.instance }}. The server may have shut down unexpectedly."
-                query: 'ipmi_chassis_power_state == 0'
-                severity: critical
               - name: IPMI chassis drive fault
                 description: "IPMI reports a drive fault on {{ $labels.instance }}. Check disk health."
                 query: 'ipmi_chassis_drive_fault_state == 0'
@@ -544,13 +564,33 @@ groups:
                 severity: critical
                 comments: |
                   The metric uses inverted logic: 1=no fault, 0=fault detected.
-              - name: IPMI SEL almost full
-                description: "IPMI System Event Log on {{ $labels.instance }} has only {{ printf \"%.0f\" $value }} bytes free. Clear the SEL to prevent loss of new events."
-                query: 'ipmi_sel_free_space_bytes < 512'
+              - name: IPMI temperature sensor warning
+                description: "IPMI temperature sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
+                query: 'ipmi_temperature_state == 1'
                 severity: warning
                 for: 5m
                 comments: |
-                  SEL storage is typically very limited (e.g., 16KB). When full, new events may be dropped.
+                  State values: 0=nominal, 1=warning, 2=critical. Thresholds are defined in the BMC firmware.
+              - name: IPMI fan speed sensor warning
+                description: "IPMI fan sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
+                query: 'ipmi_fan_speed_state == 1'
+                severity: warning
+                for: 5m
+              - name: IPMI voltage sensor warning
+                description: "IPMI voltage sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
+                query: 'ipmi_voltage_state == 1'
+                severity: warning
+                for: 5m
+              - name: IPMI current sensor warning
+                description: "IPMI current sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
+                query: 'ipmi_current_state == 1'
+                severity: warning
+                for: 5m
+              - name: IPMI power sensor warning
+                description: "IPMI power sensor {{ $labels.name }} on {{ $labels.instance }} is in warning state."
+                query: 'ipmi_power_state == 1'
+                severity: warning
+                for: 5m
 
       - name: Docker containers
         logo: /images/services/docker-containers.svg
@@ -559,6 +599,9 @@ groups:
             slug: google-cadvisor
             doc_url: https://github.com/google/cadvisor
             rules:
+              #
+              # Availability
+              #
               - name: Container killed
                 description: A container has disappeared
                 query: "time() - container_last_seen > 60"
@@ -572,22 +615,15 @@ groups:
                 for: 5m
                 comments: |
                   This rule can be very noisy in dynamic infra with legitimate container start/stop/deployment.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Container High CPU utilization
                 description: 'Container CPU utilization is above 80% (current: {{ $value | printf "%.2f" }}%)'
                 query: '(sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (pod, container) / sum(container_spec_cpu_quota{container!=""}/container_spec_cpu_period{container!=""}) by (pod, container) * 100) > 80 and sum(container_spec_cpu_quota{container!=""}/container_spec_cpu_period{container!=""}) by (pod, container) > 0'
                 comments: |
                   Only fires for containers with explicit CPU limits. Containers without limits have cpu_quota=0, which is filtered out by the guard.
-                severity: warning
-                for: 2m
-              - name: Container High Memory usage
-                description: Container Memory usage is above 80%
-                query: '(sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) > 80'
-                severity: warning
-                comments: See https://medium.com/faun/how-much-is-too-much-the-linux-oomkiller-and-used-memory-d32186f29c9d
-                for: 2m
-              - name: Container Volume usage
-                description: Container Volume usage is above 80%
-                query: '(1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total) BY (instance))) * 100 > 80 and sum(container_fs_inodes_total) BY (instance) > 0'
                 severity: warning
                 for: 2m
               - name: Container high throttle rate
@@ -604,11 +640,26 @@ groups:
                 query: '(sum(rate(container_cpu_usage_seconds_total{container!=""}[5m])) by (pod, container) / sum(container_spec_cpu_quota{container!=""}/container_spec_cpu_period{container!=""}) by (pod, container) * 100) < 20 and sum(container_spec_cpu_quota{container!=""}/container_spec_cpu_period{container!=""}) by (pod, container) > 0'
                 severity: info
                 for: 7d
+              - name: Container High Memory usage
+                description: Container Memory usage is above 80%
+                query: '(sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) > 80'
+                severity: warning
+                comments: See https://medium.com/faun/how-much-is-too-much-the-linux-oomkiller-and-used-memory-d32186f29c9d
+                for: 2m
               - name: Container Low Memory usage
                 description: Container Memory usage is under 20% for 1 week. Consider reducing the allocated memory.
                 query: '(sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) < 20'
                 severity: info
                 for: 7d
+              - name: Container Volume usage
+                description: Container Volume usage is above 80%
+                query: '(1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total) BY (instance))) * 100 > 80 and sum(container_fs_inodes_total) BY (instance) > 0'
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Container Unhealthy
                 description: Container {{ $labels.name }} on {{ $labels.instance }} has been reporting an unhealthy Docker health check status for more than 5m
                 query: 'container_health_state == 0'
@@ -624,29 +675,46 @@ groups:
             slug: blackbox-exporter
             doc_url: https://github.com/prometheus/blackbox_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Blackbox probe failed
                 description: Probe failed
                 query: probe_success == 0
                 severity: critical
-                for: 1m
-              - name: Blackbox configuration reload failure
-                description: Blackbox configuration reload failure
-                query: "blackbox_exporter_config_last_reload_successful != 1"
-                severity: warning
-              - name: Blackbox slow probe
-                description: Blackbox probe took more than 1s to complete
-                query: "probe_duration_seconds > 1"
-                severity: warning
                 for: 1m
               - name: Blackbox probe HTTP failure
                 description: HTTP status code is not 200-399
                 query: "probe_http_status_code <= 199 OR probe_http_status_code >= 400"
                 severity: critical
                 for: 1m
-              - name: Blackbox SSL certificate will expire soon
-                description: SSL certificate expires in less than 20 days
-                query: "3 <= round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 20"
+              - name: Blackbox probe low uptime
+                description: Blackbox probe has had lower uptime than 99.9% over the last 30 days, which may indicate cumulative outages or repeated flapping not caught by immediate down alerts.
+                query: 'avg_over_time(probe_success{job="blackbox-exporter"}[30d]) * 100 < 99.9'
+                severity: info
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Blackbox slow probe
+                description: Blackbox probe took more than 1s to complete
+                query: "probe_duration_seconds > 1"
                 severity: warning
+                for: 1m
+              - name: Blackbox probe slow HTTP
+                description: HTTP request took more than 1s
+                query: "sum by (instance) (probe_http_duration_seconds) > 1"
+                severity: warning
+                for: 1m
+              - name: Blackbox probe slow ping
+                description: Blackbox ping took more than 1s
+                query: "sum by (instance) (probe_icmp_duration_seconds) > 1"
+                severity: warning
+                for: 1m
+
+              #
+              # Info, security, and config
+              #
               - name: Blackbox SSL certificate will expire very soon
                 description: SSL certificate expires in less than 3 days
                 query: "0 <= round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 3"
@@ -660,20 +728,14 @@ groups:
                   need to enable insecure_skip_verify. Note that this will disable
                   certificate validation.
                   See https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md#tls_config
-              - name: Blackbox probe slow HTTP
-                description: HTTP request took more than 1s
-                query: "sum by (instance) (probe_http_duration_seconds) > 1"
+              - name: Blackbox configuration reload failure
+                description: Blackbox configuration reload failure
+                query: "blackbox_exporter_config_last_reload_successful != 1"
                 severity: warning
-                for: 1m
-              - name: Blackbox probe slow ping
-                description: Blackbox ping took more than 1s
-                query: "sum by (instance) (probe_icmp_duration_seconds) > 1"
+              - name: Blackbox SSL certificate will expire soon
+                description: SSL certificate expires in less than 20 days
+                query: "3 <= round((last_over_time(probe_ssl_earliest_cert_expiry[10m]) - time()) / 86400, 0.1) < 20"
                 severity: warning
-                for: 1m
-              - name: Blackbox probe low uptime
-                description: Blackbox probe has had lower uptime than 99.9% over the last 30 days, which may indicate cumulative outages or repeated flapping not caught by immediate down alerts.
-                query: 'avg_over_time(probe_success{job="blackbox-exporter"}[30d]) * 100 < 99.9'
-                severity: info
 
       - name: Windows Server
         logo: /images/services/windows-server.svg
@@ -682,15 +744,9 @@ groups:
             slug: windows-exporter
             doc_url: https://github.com/prometheus-community/windows_exporter
             rules:
-              - name: Windows Server collector Error
-                description: "Collector {{ $labels.collector }} was not successful"
-                query: "windows_exporter_collector_success == 0"
-                severity: critical
-              - name: Windows Server service Status
-                description: Windows Service state is not OK
-                query: 'windows_service_state{state="running"} == 0'
-                severity: critical
-                for: 1m
+              #
+              # Resource saturation (USE)
+              #
               - name: Windows Server CPU Usage
                 description: CPU Usage is more than 80%
                 query: '100 - (avg by (instance) (rate(windows_cpu_time_total{mode="idle"}[2m])) * 100) > 80'
@@ -715,6 +771,23 @@ groups:
                 query: "windows_time_ntp_round_trip_delay_seconds > 1"
                 severity: warning
                 for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Windows Server collector Error
+                description: "Collector {{ $labels.collector }} was not successful"
+                query: "windows_exporter_collector_success == 0"
+                severity: critical
+              - name: Windows Server service Status
+                description: Windows Service state is not OK
+                query: 'windows_service_state{state="running"} == 0'
+                severity: critical
+                for: 1m
+
+              #
+              # Info, security, and config
+              #
               - name: Windows Server clock offset
                 description: System clock on {{ $labels.instance }} is offset from its configured time source by more than 1 second, which can break Kerberos authentication, Active Directory replication and log correlation.
                 query: "windows_time_computed_time_offset_seconds > 1"
@@ -728,16 +801,23 @@ groups:
             slug: pryorda-vmware-exporter
             doc_url: https://github.com/pryorda/vmware_exporter
             rules:
-              - name: Virtual Machine Memory Warning
-                description: 'High memory usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
-                query: "vmware_vm_mem_usage_average / 100 >= 90 and vmware_vm_mem_usage_average / 100 < 95"
-                severity: warning
-                for: 10m
+              #
+              # Resource saturation (USE)
+              #
               - name: Virtual Machine Memory Critical
                 description: 'High memory usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
                 query: "vmware_vm_mem_usage_average / 100 >= 95"
                 severity: critical
                 for: 10m
+              - name: Virtual Machine Memory Warning
+                description: 'High memory usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
+                query: "vmware_vm_mem_usage_average / 100 >= 90 and vmware_vm_mem_usage_average / 100 < 95"
+                severity: warning
+                for: 10m
+
+              #
+              # Capacity and trend
+              #
               - name: High Number of Snapshots
                 description: "High snapshots number on {{ $labels.instance }}: {{ $value }}"
                 query: "vmware_vm_snapshots > 3"
@@ -756,11 +836,21 @@ groups:
             slug: prometheus-pve-exporter
             doc_url: https://github.com/prometheus-pve/prometheus-pve-exporter
             rules:
+              #
+              # Availability
+              #
               - name: PVE node down
                 description: 'Proxmox VE node {{ $labels.id }} is down.'
                 query: 'pve_up{id=~"node/.*"} == 0'
                 severity: critical
                 for: 2m
+              - name: PVE cluster not quorate
+                description: 'Proxmox VE cluster has lost quorum.'
+                query: 'pve_cluster_info{quorate="0"} == 1'
+                severity: critical
+                comments: |
+                  Loss of quorum means the cluster cannot make decisions about VM placement
+                  and fencing. This requires immediate attention.
               - name: PVE VM/CT down
                 description: 'Proxmox VE guest {{ $labels.id }} is not running.'
                 query: 'pve_up{id=~"(qemu|lxc)/.*"} == 0'
@@ -770,6 +860,10 @@ groups:
                   This alert triggers for all VMs and containers that are not running.
                   You may want to filter by specific guests using the `id` label, or exclude
                   intentionally stopped guests with additional label matchers.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: PVE high CPU usage
                 description: 'Proxmox VE CPU usage is above 90% on {{ $labels.id }}. Current value: {{ $value | printf "%.2f" }}%'
                 query: 'pve_cpu_usage_ratio * 100 > 90'
@@ -780,31 +874,32 @@ groups:
                 query: 'pve_memory_usage_bytes / pve_memory_size_bytes * 100 > 90 and pve_memory_size_bytes > 0'
                 severity: warning
                 for: 5m
-              - name: PVE storage filling up
-                description: 'Proxmox VE storage {{ $labels.id }} is above 80% used. Current value: {{ $value | printf "%.2f" }}%'
-                query: 'pve_disk_usage_bytes{id=~"storage/.*"} / pve_disk_size_bytes{id=~"storage/.*"} * 100 > 80 and pve_disk_size_bytes{id=~"storage/.*"} > 0'
-                severity: warning
-                for: 5m
               - name: PVE storage almost full
                 description: 'Proxmox VE storage {{ $labels.id }} is above 95% used. Current value: {{ $value | printf "%.2f" }}%'
                 query: 'pve_disk_usage_bytes{id=~"storage/.*"} / pve_disk_size_bytes{id=~"storage/.*"} * 100 > 95 and pve_disk_size_bytes{id=~"storage/.*"} > 0'
                 severity: critical
                 for: 2m
-              - name: PVE guest not backed up
-                description: '{{ $value }} Proxmox VE guest(s) are not covered by any backup job.'
-                query: 'pve_not_backed_up_total > 0'
+              - name: PVE storage filling up
+                description: 'Proxmox VE storage {{ $labels.id }} is above 80% used. Current value: {{ $value | printf "%.2f" }}%'
+                query: 'pve_disk_usage_bytes{id=~"storage/.*"} / pve_disk_size_bytes{id=~"storage/.*"} * 100 > 80 and pve_disk_size_bytes{id=~"storage/.*"} > 0'
                 severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: PVE replication failed
                 description: 'Proxmox VE replication for {{ $labels.id }} has {{ $value }} failed sync(s).'
                 query: 'pve_replication_failed_syncs > 0'
                 severity: warning
-              - name: PVE cluster not quorate
-                description: 'Proxmox VE cluster has lost quorum.'
-                query: 'pve_cluster_info{quorate="0"} == 1'
-                severity: critical
-                comments: |
-                  Loss of quorum means the cluster cannot make decisions about VM placement
-                  and fencing. This requires immediate attention.
+
+              #
+              # Capacity and trend
+              #
+              - name: PVE guest not backed up
+                description: '{{ $value }} Proxmox VE guest(s) are not covered by any backup job.'
+                query: 'pve_not_backed_up_total > 0'
+                severity: warning
 
       - name: Netdata
         logo: /images/services/netdata.svg
@@ -813,6 +908,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://github.com/netdata/netdata/blob/master/backends/prometheus/README.md
             rules:
+              #
+              # Resource saturation (USE)
+              #
               - name: Netdata high cpu usage
                 description: Netdata high CPU usage (> 80%)
                 query: 'netdata_cpu_cpu_percentage_average{dimension="idle"} < 20'
@@ -839,22 +937,26 @@ groups:
                 description: Netdata predicted disk full in 24 hours
                 query: 'predict_linear(netdata_disk_space_GB_average{dimension=~"avail|cached"}[3h], 24 * 3600) < 0'
                 severity: warning
+              - name: Netdata reported uncorrectable disk sectors
+                description: "Reported uncorrectable disk sectors ({{ $value }} sectors)"
+                query: "increase(netdata_smartd_log_offline_uncorrectable_sector_count_sectors_average[2m]) > 0"
+                severity: warning
+              - name: Netdata disk reallocated sectors
+                description: "Disk reallocated sectors detected ({{ $value }} sectors)"
+                query: "increase(netdata_smartd_log_reallocated_sectors_count_sectors_average[1m]) > 0"
+                severity: info
               - name: Netdata MD mismatch cnt unsynchronized blocks
                 description: RAID Array have unsynchronized blocks
                 query: "netdata_md_mismatch_cnt_unsynchronized_blocks_average > 1024"
                 severity: warning
                 for: 2m
-              - name: Netdata disk reallocated sectors
-                description: "Disk reallocated sectors detected ({{ $value }} sectors)"
-                query: "increase(netdata_smartd_log_reallocated_sectors_count_sectors_average[1m]) > 0"
-                severity: info
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Netdata disk current pending sector
                 description: Disk current pending sector
                 query: "netdata_smartd_log_current_pending_sector_count_sectors_average > 0"
-                severity: warning
-              - name: Netdata reported uncorrectable disk sectors
-                description: "Reported uncorrectable disk sectors ({{ $value }} sectors)"
-                query: "increase(netdata_smartd_log_offline_uncorrectable_sector_count_sectors_average[2m]) > 0"
                 severity: warning
 
       - name: eBPF
@@ -864,6 +966,18 @@ groups:
             slug: ebpf-exporter
             doc_url: https://github.com/cloudflare/ebpf_exporter
             rules:
+              #
+              # Availability
+              #
+              - name: eBPF exporter no enabled configs
+                description: "eBPF exporter has no enabled configurations. No eBPF programs are being run. (instance {{ $labels.instance }})"
+                query: 'ebpf_exporter_enabled_configs == 0 or absent(ebpf_exporter_enabled_configs)'
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: eBPF exporter program not attached
                 description: "eBPF program {{ $labels.id }} failed to attach. The program is not collecting data. (instance {{ $labels.instance }})"
                 query: 'ebpf_exporter_ebpf_program_attached == 0'
@@ -876,11 +990,6 @@ groups:
                 query: 'rate(ebpf_exporter_decoder_errors_total[5m]) > 0.05'
                 severity: warning
                 for: 5m
-              - name: eBPF exporter no enabled configs
-                description: "eBPF exporter has no enabled configurations. No eBPF programs are being run. (instance {{ $labels.instance }})"
-                query: 'ebpf_exporter_enabled_configs == 0 or absent(ebpf_exporter_enabled_configs)'
-                severity: warning
-                for: 5m
 
       - name: Process Exporter
         logo: /images/services/process-exporter.svg
@@ -889,18 +998,18 @@ groups:
             slug: process-exporter
             doc_url: https://github.com/ncabatoff/process-exporter
             rules:
+              #
+              # Availability
+              #
               - name: Process exporter group down
                 description: "No processes found for group {{ $labels.groupname }}. The service may have stopped. (instance {{ $labels.instance }})"
                 query: 'namedprocess_namegroup_num_procs == 0'
                 severity: warning
                 for: 5m
-              - name: Process exporter high memory usage
-                description: "Process group {{ $labels.groupname }} is using {{ $value | humanize }}B of resident memory. (instance {{ $labels.instance }})"
-                query: 'namedprocess_namegroup_memory_bytes{memtype="resident"} > 4e+09'
-                severity: warning
-                for: 5m
-                comments: |
-                  Threshold of 4GB is arbitrary and depends on the process being monitored. Adjust per group.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Process exporter high CPU usage
                 description: "Process group {{ $labels.groupname }} is using {{ $value }}% CPU (core-equivalent). (instance {{ $labels.instance }})"
                 query: 'rate(namedprocess_namegroup_cpu_seconds_total[5m]) * 100 > 80'
@@ -908,35 +1017,13 @@ groups:
                 for: 5m
                 comments: |
                   Value is core-equivalent %: 100% = 1 full core, 200% = 2 cores, etc. Threshold of 80% is per-core. Adjust based on expected workload.
-              - name: Process exporter high file descriptor usage
-                description: "Process group {{ $labels.groupname }} is using more than 80% of its file descriptor limit. (instance {{ $labels.instance }})"
-                query: 'namedprocess_namegroup_worst_fd_ratio > 0.8'
-                severity: warning
-                for: 5m
-              - name: Process exporter file descriptors exhausted
-                description: "Process group {{ $labels.groupname }} has nearly exhausted its file descriptor limit. (instance {{ $labels.instance }})"
-                query: 'namedprocess_namegroup_worst_fd_ratio > 0.95'
-                severity: critical
-                for: 2m
-              - name: Process exporter high swap usage
-                description: "Process group {{ $labels.groupname }} is using {{ $value | humanize }}B of swap. (instance {{ $labels.instance }})"
-                query: 'namedprocess_namegroup_memory_bytes{memtype="swapped"} > 512e+06'
+              - name: Process exporter high memory usage
+                description: "Process group {{ $labels.groupname }} is using {{ $value | humanize }}B of resident memory. (instance {{ $labels.instance }})"
+                query: 'namedprocess_namegroup_memory_bytes{memtype="resident"} > 4e+09'
                 severity: warning
                 for: 5m
                 comments: |
-                  Threshold of 512MB is arbitrary. Adjust per group and environment.
-              - name: Process exporter zombie processes
-                description: "Process group {{ $labels.groupname }} has {{ $value }} zombie processes. (instance {{ $labels.instance }})"
-                query: 'namedprocess_namegroup_states{state="Zombie"} > 5'
-                severity: warning
-                for: 5m
-              - name: Process exporter high context switching
-                description: "Process group {{ $labels.groupname }} has a high rate of context switches ({{ $value }}/s). (instance {{ $labels.instance }})"
-                query: 'rate(namedprocess_namegroup_context_switches_total{ctxswitchtype="voluntary"}[5m]) > 50000'
-                severity: warning
-                for: 5m
-                comments: |
-                  Filters to voluntary switches only — involuntary switches are normal under CPU contention. Threshold of 50000/s is a rough default. Adjust based on workload.
+                  Threshold of 4GB is arbitrary and depends on the process being monitored. Adjust per group.
               - name: Process exporter high disk write IO
                 description: "Process group {{ $labels.groupname }} is performing {{ $value | humanize }}B/s of disk writes. (instance {{ $labels.instance }})"
                 query: 'rate(namedprocess_namegroup_write_bytes_total[5m]) > 100e+06'
@@ -944,6 +1031,39 @@ groups:
                 for: 5m
                 comments: |
                   Threshold of 100MB/s is arbitrary. Adjust per group.
+              - name: Process exporter file descriptors exhausted
+                description: "Process group {{ $labels.groupname }} has nearly exhausted its file descriptor limit. (instance {{ $labels.instance }})"
+                query: 'namedprocess_namegroup_worst_fd_ratio > 0.95'
+                severity: critical
+                for: 2m
+              - name: Process exporter high file descriptor usage
+                description: "Process group {{ $labels.groupname }} is using more than 80% of its file descriptor limit. (instance {{ $labels.instance }})"
+                query: 'namedprocess_namegroup_worst_fd_ratio > 0.8'
+                severity: warning
+                for: 5m
+              - name: Process exporter high swap usage
+                description: "Process group {{ $labels.groupname }} is using {{ $value | humanize }}B of swap. (instance {{ $labels.instance }})"
+                query: 'namedprocess_namegroup_memory_bytes{memtype="swapped"} > 512e+06'
+                severity: warning
+                for: 5m
+                comments: |
+                  Threshold of 512MB is arbitrary. Adjust per group and environment.
+              - name: Process exporter high context switching
+                description: "Process group {{ $labels.groupname }} has a high rate of context switches ({{ $value }}/s). (instance {{ $labels.instance }})"
+                query: 'rate(namedprocess_namegroup_context_switches_total{ctxswitchtype="voluntary"}[5m]) > 50000'
+                severity: warning
+                for: 5m
+                comments: |
+                  Filters to voluntary switches only — involuntary switches are normal under CPU contention. Threshold of 50000/s is a rough default. Adjust based on workload.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Process exporter zombie processes
+                description: "Process group {{ $labels.groupname }} has {{ $value }} zombie processes. (instance {{ $labels.instance }})"
+                query: 'namedprocess_namegroup_states{state="Zombie"} > 5'
+                severity: warning
+                for: 5m
               - name: Process exporter process restarting
                 description: "Process group {{ $labels.groupname }} has restarted (oldest process start time changed). (instance {{ $labels.instance }})"
                 query: 'changes(namedprocess_namegroup_oldest_start_time_seconds[5m]) > 0 and namedprocess_namegroup_num_procs > 0'
@@ -958,6 +1078,34 @@ groups:
             slug: systemd-exporter
             doc_url: https://github.com/prometheus-community/systemd_exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Systemd unit tasks near limit
+                description: "Systemd unit {{ $labels.name }} is using {{ $value | humanizePercentage }} of its task limit. (instance {{ $labels.instance }})"
+                query: 'systemd_unit_tasks_current / ignoring(type) systemd_unit_tasks_max > 0.9 and ignoring(type) systemd_unit_tasks_max > 0'
+                severity: warning
+                for: 5m
+              # The exporter declares this GaugeValue, but that is an upstream mistyping: NRefused and
+              # NAccepted are the same D-Bus uint32 read on adjacent lines, yet only NAccepted gets
+              # CounterValue. systemd's n_refused is increment-only and resets when the unit restarts,
+              # i.e. a counter. increase() corrects that reset; delta() would swallow the refusals.
+              - name: Systemd socket high connections
+                description: "Systemd socket {{ $labels.name }} has {{ $value }} active connections. (instance {{ $labels.instance }})"
+                query: 'systemd_socket_current_connections > 100'
+                severity: warning
+                for: 2m
+                comments: |
+                  Threshold of 100 connections is arbitrary. Adjust to your workload.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Systemd service crash looping
+                description: "Systemd service {{ $labels.name }} has restarted {{ $value }} times in the last hour. (instance {{ $labels.instance }})"
+                query: 'increase(systemd_service_restart_total[1h]) > 5'
+                severity: critical
+                for: 5m
               - name: Systemd unit failed
                 description: "Systemd unit {{ $labels.name }} has entered failed state. (instance {{ $labels.instance }})"
                 query: 'systemd_unit_state{state="failed"} == 1'
@@ -970,32 +1118,11 @@ groups:
                 for: 5m
                 comments: |
                   Many units are legitimately inactive. You must adjust the name=~ filter to match your critical services.
-              - name: Systemd service crash looping
-                description: "Systemd service {{ $labels.name }} has restarted {{ $value }} times in the last hour. (instance {{ $labels.instance }})"
-                query: 'increase(systemd_service_restart_total[1h]) > 5'
-                severity: critical
-                for: 5m
-              - name: Systemd unit tasks near limit
-                description: "Systemd unit {{ $labels.name }} is using {{ $value | humanizePercentage }} of its task limit. (instance {{ $labels.instance }})"
-                query: 'systemd_unit_tasks_current / ignoring(type) systemd_unit_tasks_max > 0.9 and ignoring(type) systemd_unit_tasks_max > 0'
-                severity: warning
-                for: 5m
-              # The exporter declares this GaugeValue, but that is an upstream mistyping: NRefused and
-              # NAccepted are the same D-Bus uint32 read on adjacent lines, yet only NAccepted gets
-              # CounterValue. systemd's n_refused is increment-only and resets when the unit restarts,
-              # i.e. a counter. increase() corrects that reset; delta() would swallow the refusals.
               - name: Systemd socket refused connections
                 description: "Systemd socket {{ $labels.name }} is refusing connections. ({{ $value }} refused in last 5m, instance {{ $labels.instance }})"
                 query: 'increase(systemd_socket_refused_connections_total[5m]) > 3'
                 severity: warning
                 for: 2m
-              - name: Systemd socket high connections
-                description: "Systemd socket {{ $labels.name }} has {{ $value }} active connections. (instance {{ $labels.instance }})"
-                query: 'systemd_socket_current_connections > 100'
-                severity: warning
-                for: 2m
-                comments: |
-                  Threshold of 100 connections is arbitrary. Adjust to your workload.
               - name: Systemd timer missed trigger
                 description: "Systemd timer {{ $labels.name }} has not triggered for over 24 hours. (instance {{ $labels.instance }})"
                 query: '(time() - systemd_timer_last_trigger_seconds) / 3600 > 24 and systemd_timer_last_trigger_seconds > 0'
@@ -1013,6 +1140,9 @@ groups:
             slug: mysqld-exporter
             doc_url: https://github.com/prometheus/mysqld_exporter
             rules:
+              #
+              # Availability
+              #
               - name: MySQL down
                 description: MySQL instance is down on {{ $labels.instance }}
                 query: "mysql_up == 0"
@@ -1020,6 +1150,24 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+              - name: MySQL Slave IO thread not running
+                description: "MySQL Slave IO thread not running on {{ $labels.instance }}"
+                query: "( mysql_slave_status_slave_io_running and ON (instance) mysql_slave_status_master_server_id > 0 ) == 0"
+                severity: critical
+                for: 1m
+                comments: |
+                  1m delay allows a restart without triggering an alert.
+              - name: MySQL Slave SQL thread not running
+                description: "MySQL Slave SQL thread not running on {{ $labels.instance }}"
+                query: "( mysql_slave_status_slave_sql_running and ON (instance) mysql_slave_status_master_server_id > 0) == 0"
+                severity: critical
+                for: 1m
+                comments: |
+                  1m delay allows a restart without triggering an alert.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: MySQL too many connections (> 80%)
                 description: "More than 80% of MySQL connections are in use on {{ $labels.instance }}"
                 query: "max_over_time(mysql_global_status_threads_connected[1m]) / mysql_global_variables_max_connections * 100 > 80 and mysql_global_variables_max_connections > 0"
@@ -1035,20 +1183,10 @@ groups:
                 query: "max_over_time(mysql_global_status_threads_running[1m]) / mysql_global_variables_max_connections * 100 > 60 and mysql_global_variables_max_connections > 0"
                 severity: warning
                 for: 2m
-              - name: MySQL Slave IO thread not running
-                description: "MySQL Slave IO thread not running on {{ $labels.instance }}"
-                query: "( mysql_slave_status_slave_io_running and ON (instance) mysql_slave_status_master_server_id > 0 ) == 0"
-                severity: critical
-                for: 1m
-                comments: |
-                  1m delay allows a restart without triggering an alert.
-              - name: MySQL Slave SQL thread not running
-                description: "MySQL Slave SQL thread not running on {{ $labels.instance }}"
-                query: "( mysql_slave_status_slave_sql_running and ON (instance) mysql_slave_status_master_server_id > 0) == 0"
-                severity: critical
-                for: 1m
-                comments: |
-                  1m delay allows a restart without triggering an alert.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: MySQL Slave replication lag
                 description: "MySQL replication lag on {{ $labels.instance }}"
                 query: "( (mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay) and ON (instance) mysql_slave_status_master_server_id > 0 ) > 30"
@@ -1058,43 +1196,6 @@ groups:
               # else, including Slow_queries, falls back to Untyped. MySQL increments it cumulatively
               # since server start and resets it on restart or FLUSH STATUS, i.e. a counter, so
               # increase() is correct — see the InnoDB log waits rule below for the same pattern.
-              - name: MySQL slow queries
-                description: "MySQL server has some new slow queries ({{ $value }} in the last minute)."
-                query: increase(mysql_global_status_slow_queries[1m]) > 0
-                severity: warning
-                for: 2m
-              - name: MySQL InnoDB log waits
-                description: "MySQL innodb log writes stalling ({{ $value }} waits/s)"
-                query: rate(mysql_global_status_innodb_log_waits[15m]) > 10
-                severity: warning
-              - name: MySQL restarted
-                description: MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.
-                query: "mysql_global_status_uptime < 60"
-                severity: info
-              # mysqld_exporter only types the six SHOW GLOBAL STATUS prefixes it recognises; everything
-              # else, including Questions, falls back to Untyped. MySQL increments it cumulatively since
-              # server start and resets it on restart or FLUSH STATUS, i.e. a counter, so rate() is
-              # correct. Both rate() and deriv() are per-second, so the 10k QPS threshold is unaffected.
-              - name: MySQL High QPS
-                description: MySQL is being overload with unusual QPS (> 10k QPS).
-                query: "rate(mysql_global_status_questions[1m]) > 10000"
-                severity: info
-                for: 2m
-              - name: MySQL too many open files
-                description: MySQL has too many open files, consider increase variables open_files_limit on {{ $labels.instance }}.
-                query: "mysql_global_status_innodb_num_open_files / mysql_global_variables_open_files_limit * 100 > 75 and mysql_global_variables_open_files_limit > 0"
-                severity: warning
-                for: 2m
-              - name: MySQL InnoDB Force Recovery is enabled
-                description: "MySQL InnoDB force recovery is enabled on {{ $labels.instance }}"
-                query: "mysql_global_variables_innodb_force_recovery != 0"
-                severity: warning
-                for: 2m
-              - name: MySQL InnoDB history_len too long
-                description: "MySQL history_len (undo log) too long on {{ $labels.instance }}"
-                query: "mysql_info_schema_innodb_metrics_transaction_trx_rseg_history_len > 50000"
-                severity: warning
-                for: 2m
               - name: MySQL heartbeat replication lag
                 description: "MySQL replication lag on {{ $labels.instance }}"
                 query: "mysql_heartbeat_now_timestamp_seconds - mysql_heartbeat_stored_timestamp_seconds > 30"
@@ -1109,14 +1210,59 @@ groups:
                 query: "mysql_global_status_wsrep_ready != 1"
                 severity: critical
                 for: 1m
-              - name: MySQL Galera node out of sync
-                description: Galera node {{ $labels.instance }} has unexpectedly fallen out of the Synced state (wsrep_local_state != 4), excluding nodes intentionally desynced for a state transfer or backup.
-                query: "mysql_global_status_wsrep_local_state != 4 and mysql_global_variables_wsrep_desync == 0"
+              - name: MySQL slow queries
+                description: "MySQL server has some new slow queries ({{ $value }} in the last minute)."
+                query: increase(mysql_global_status_slow_queries[1m]) > 0
+                severity: warning
+                for: 2m
+              - name: MySQL InnoDB log waits
+                description: "MySQL innodb log writes stalling ({{ $value }} waits/s)"
+                query: rate(mysql_global_status_innodb_log_waits[15m]) > 10
+                severity: warning
+              - name: MySQL too many open files
+                description: MySQL has too many open files, consider increase variables open_files_limit on {{ $labels.instance }}.
+                query: "mysql_global_status_innodb_num_open_files / mysql_global_variables_open_files_limit * 100 > 75 and mysql_global_variables_open_files_limit > 0"
+                severity: warning
+                for: 2m
+              - name: MySQL InnoDB history_len too long
+                description: "MySQL history_len (undo log) too long on {{ $labels.instance }}"
+                query: "mysql_info_schema_innodb_metrics_transaction_trx_rseg_history_len > 50000"
                 severity: warning
                 for: 2m
               - name: MySQL Galera donor falling behind
                 description: Galera donor node {{ $labels.instance }} serving a state transfer has a growing receive queue ({{ $value }} entries), indicating it is falling behind the rest of the cluster.
                 query: "mysql_global_status_wsrep_local_state == 2 and mysql_global_status_wsrep_local_recv_queue > 100"
+                severity: warning
+                for: 2m
+              - name: MySQL restarted
+                description: MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.
+                query: "mysql_global_status_uptime < 60"
+                severity: info
+              # mysqld_exporter only types the six SHOW GLOBAL STATUS prefixes it recognises; everything
+              # else, including Questions, falls back to Untyped. MySQL increments it cumulatively since
+              # server start and resets it on restart or FLUSH STATUS, i.e. a counter, so rate() is
+              # correct. Both rate() and deriv() are per-second, so the 10k QPS threshold is unaffected.
+              - name: MySQL High QPS
+                description: MySQL is being overload with unusual QPS (> 10k QPS).
+                query: "rate(mysql_global_status_questions[1m]) > 10000"
+                severity: info
+                for: 2m
+
+              #
+              # Capacity and trend
+              #
+              - name: MySQL Galera node out of sync
+                description: Galera node {{ $labels.instance }} has unexpectedly fallen out of the Synced state (wsrep_local_state != 4), excluding nodes intentionally desynced for a state transfer or backup.
+                query: "mysql_global_status_wsrep_local_state != 4 and mysql_global_variables_wsrep_desync == 0"
+                severity: warning
+                for: 2m
+
+              #
+              # Info, security, and config
+              #
+              - name: MySQL InnoDB Force Recovery is enabled
+                description: "MySQL InnoDB force recovery is enabled on {{ $labels.instance }}"
+                query: "mysql_global_variables_innodb_force_recovery != 0"
                 severity: warning
                 for: 2m
 
@@ -1127,6 +1273,9 @@ groups:
             slug: postgres-exporter
             doc_url: https://github.com/prometheus-community/postgres_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Postgresql down
                 description: Postgresql instance is down
                 query: "pg_up == 0"
@@ -1134,6 +1283,62 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+              - name: Postgresql replication role changed
+                description: The replication role (primary/replica) of {{ $labels.instance }} has just changed, which usually indicates a failover happened. Verify whether this was expected.
+                query: "pg_replication_is_replica and changes(pg_replication_is_replica[1m]) > 0"
+                severity: warning
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Postgresql bloat index high (> 80%)
+                description: "The index {{ $labels.idxname }} is bloated. You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`"
+                query: "pg_bloat_btree_bloat_pct > 80 and on (idxname) (pg_bloat_btree_real_size > 100000000)"
+                severity: warning
+                for: 1h
+                comments: |
+                  See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
+              - name: Postgresql bloat table high (> 80%)
+                description: "The table {{ $labels.relname }} is bloated. You should execute `VACUUM {{ $labels.relname }};`"
+                query: "pg_bloat_table_bloat_pct > 80 and on (relname) (pg_bloat_table_real_size > 200000000)"
+                severity: warning
+                for: 1h
+                comments: |
+                  See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
+              - name: Postgresql long-running transaction
+                description: A transaction on database {{ $labels.datname }} has been running for more than 2 minutes, which can hold locks, cause table bloat, and delay replication.
+                query: 'avg by (datname) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres"}) > 2 * 60'
+                severity: warning
+                for: 2m
+              - name: Postgresql low cache hit rate
+                description: PostgreSQL buffer cache hit rate for database {{ $labels.datname }} is {{ $value | humanizePercentage }}, below the 98% target, indicating heavy disk I/O; consider increasing shared_buffers.
+                query: 'sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) / (sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) + sum by (datname) (rate(pg_stat_database_blks_read{datname!~"template.*|postgres",datid!="0"}[5m]))) < 0.98 and (sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) + sum by (datname) (rate(pg_stat_database_blks_read{datname!~"template.*|postgres",datid!="0"}[5m]))) > 0'
+                severity: warning
+                for: 5m
+              - name: Postgresql not enough connections
+                description: PostgreSQL instance should have more connections (> 5)
+                query: 'sum by (datname) (pg_stat_activity_count{datname!~"template.*|postgres"}) < 5'
+                severity: critical
+                for: 2m
+              - name: Postgresql too many locks acquired
+                description: Too many locks acquired on the database. If this alert happens frequently, we may need to increase the postgres setting max_locks_per_transaction.
+                query: "((sum by (instance) (pg_locks_count)) / (pg_settings_max_locks_per_transaction * pg_settings_max_connections)) > 0.20 and (pg_settings_max_locks_per_transaction * pg_settings_max_connections) > 0"
+                severity: critical
+                for: 2m
+              - name: Postgresql max connections reached
+                description: PostgreSQL instance {{ $labels.instance }} has reached the maximum usable connection limit (max_connections minus superuser_reserved_connections). New client connections will be rejected until connections free up.
+                query: "sum by (instance, job, server) (pg_stat_activity_count) >= (min by (instance, job, server) (pg_settings_max_connections) - min by (instance, job, server) (pg_settings_superuser_reserved_connections))"
+                severity: critical
+                for: 1m
+              - name: Postgresql too many connections
+                description: PostgreSQL instance has too many connections (> 80%).
+                query: "sum by (instance, job, server) (pg_stat_activity_count) > min by (instance, job, server) ((pg_settings_max_connections - pg_settings_superuser_reserved_connections) * 0.8)"
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Postgresql restarted
                 description: Postgresql restarted
                 query: "time() - pg_postmaster_start_time_seconds < 60"
@@ -1142,6 +1347,11 @@ groups:
                 description: Postgresql exporter is showing errors. A query may be buggy in query.yaml
                 query: "pg_exporter_last_scrape_error > 0"
                 severity: critical
+              - name: Postgresql commit rate low
+                description: Postgresql seems to be processing very few transactions
+                query: 'increase(pg_stat_database_xact_commit{datname!~"template.*|postgres",datid!="0"}[5m]) < 5'
+                severity: critical
+                for: 2m
               - name: Postgresql table not auto vacuumed
                 description: Table {{ $labels.relname }} has not been auto vacuumed for 10 days
                 query: "((pg_stat_user_tables_n_tup_del + pg_stat_user_tables_n_tup_upd + pg_stat_user_tables_n_tup_hot_upd) > pg_settings_autovacuum_vacuum_threshold) and (time() - pg_stat_user_tables_last_autovacuum) > 60 * 60 * 24 * 10"
@@ -1150,16 +1360,6 @@ groups:
                 description: Table {{ $labels.relname }} has not been auto analyzed for 10 days
                 query: "((pg_stat_user_tables_n_tup_del + pg_stat_user_tables_n_tup_upd + pg_stat_user_tables_n_tup_hot_upd) > pg_settings_autovacuum_analyze_threshold) and (time() - pg_stat_user_tables_last_autoanalyze) > 24 * 60 * 60 * 10"
                 severity: warning
-              - name: Postgresql too many connections
-                description: PostgreSQL instance has too many connections (> 80%).
-                query: "sum by (instance, job, server) (pg_stat_activity_count) > min by (instance, job, server) ((pg_settings_max_connections - pg_settings_superuser_reserved_connections) * 0.8)"
-                severity: warning
-                for: 2m
-              - name: Postgresql not enough connections
-                description: PostgreSQL instance should have more connections (> 5)
-                query: 'sum by (datname) (pg_stat_activity_count{datname!~"template.*|postgres"}) < 5'
-                severity: critical
-                for: 2m
               - name: Postgresql dead locks
                 description: "PostgreSQL has dead-locks ({{ $value }} in the last minute)"
                 query: 'increase(pg_stat_database_deadlocks{datname!~"template.*|postgres",datid!="0"}[1m]) > 5'
@@ -1168,11 +1368,6 @@ groups:
                 description: Ratio of transactions being aborted compared to committed is > 10 %
                 query: 'sum by (namespace,datname,instance) (rate(pg_stat_database_xact_rollback{datname!~"template.*|postgres",datid!="0"}[3m])) / (sum by (namespace,datname,instance) (rate(pg_stat_database_xact_rollback{datname!~"template.*|postgres",datid!="0"}[3m])) + sum by (namespace,datname,instance) (rate(pg_stat_database_xact_commit{datname!~"template.*|postgres",datid!="0"}[3m]))) > 0.10 and (sum by (namespace,datname,instance) (rate(pg_stat_database_xact_rollback{datname!~"template.*|postgres",datid!="0"}[3m])) + sum by (namespace,datname,instance) (rate(pg_stat_database_xact_commit{datname!~"template.*|postgres",datid!="0"}[3m]))) > 0'
                 severity: warning
-              - name: Postgresql commit rate low
-                description: Postgresql seems to be processing very few transactions
-                query: 'increase(pg_stat_database_xact_commit{datname!~"template.*|postgres",datid!="0"}[5m]) < 5'
-                severity: critical
-                for: 2m
               - name: Postgresql low XID consumption
                 description: Postgresql seems to be consuming transaction IDs very slowly
                 query: "rate(pg_txid_current[1m]) < 5"
@@ -1190,35 +1385,6 @@ groups:
                 query: "((pg_stat_user_tables_n_dead_tup > 10000) / (pg_stat_user_tables_n_live_tup + pg_stat_user_tables_n_dead_tup)) >= 0.1 and (pg_stat_user_tables_n_live_tup + pg_stat_user_tables_n_dead_tup) > 0"
                 severity: warning
                 for: 2m
-              - name: Postgresql configuration changed
-                description: Postgres Database configuration change has occurred
-                query: '{__name__=~"pg_settings_.*",__name__!="pg_settings_transaction_read_only"} != ON(__name__, instance) {__name__=~"pg_settings_.*",__name__!="pg_settings_transaction_read_only"} OFFSET 5m'
-                severity: info
-              - name: Postgresql SSL compression active
-                description: Database allows connections with SSL compression enabled. This may add significant jitter in replication delay. Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
-                query: "sum by (instance) (pg_stat_ssl_compression) > 0"
-                severity: warning
-                comments: |
-                  pg_stat_ssl_compression is not a default postgres_exporter metric and is only available on PostgreSQL 9.5-13 (removed in PG 14). See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
-              - name: Postgresql too many locks acquired
-                description: Too many locks acquired on the database. If this alert happens frequently, we may need to increase the postgres setting max_locks_per_transaction.
-                query: "((sum by (instance) (pg_locks_count)) / (pg_settings_max_locks_per_transaction * pg_settings_max_connections)) > 0.20 and (pg_settings_max_locks_per_transaction * pg_settings_max_connections) > 0"
-                severity: critical
-                for: 2m
-              - name: Postgresql bloat index high (> 80%)
-                description: "The index {{ $labels.idxname }} is bloated. You should execute `REINDEX INDEX CONCURRENTLY {{ $labels.idxname }};`"
-                query: "pg_bloat_btree_bloat_pct > 80 and on (idxname) (pg_bloat_btree_real_size > 100000000)"
-                severity: warning
-                for: 1h
-                comments: |
-                  See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
-              - name: Postgresql bloat table high (> 80%)
-                description: "The table {{ $labels.relname }} is bloated. You should execute `VACUUM {{ $labels.relname }};`"
-                query: "pg_bloat_table_bloat_pct > 80 and on (relname) (pg_bloat_table_real_size > 200000000)"
-                severity: warning
-                for: 1h
-                comments: |
-                  See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
               - name: Postgresql invalid index
                 description: "The table {{ $labels.relname }} has an invalid index: {{ $labels.indexrelname }}. You should execute `DROP INDEX {{ $labels.indexrelname }};`"
                 query: 'pg_general_index_info_pg_relation_size{indexrelname=~".*ccnew.*"}'
@@ -1231,30 +1397,25 @@ groups:
                 query: "pg_replication_lag_seconds > 5"
                 severity: warning
                 for: 30s
-              - name: Postgresql long-running transaction
-                description: A transaction on database {{ $labels.datname }} has been running for more than 2 minutes, which can hold locks, cause table bloat, and delay replication.
-                query: 'avg by (datname) (pg_stat_activity_max_tx_duration{datname!~"template.*|postgres"}) > 2 * 60'
-                severity: warning
-                for: 2m
-              - name: Postgresql low cache hit rate
-                description: PostgreSQL buffer cache hit rate for database {{ $labels.datname }} is {{ $value | humanizePercentage }}, below the 98% target, indicating heavy disk I/O; consider increasing shared_buffers.
-                query: 'sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) / (sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) + sum by (datname) (rate(pg_stat_database_blks_read{datname!~"template.*|postgres",datid!="0"}[5m]))) < 0.98 and (sum by (datname) (rate(pg_stat_database_blks_hit{datname!~"template.*|postgres",datid!="0"}[5m])) + sum by (datname) (rate(pg_stat_database_blks_read{datname!~"template.*|postgres",datid!="0"}[5m]))) > 0'
-                severity: warning
-                for: 5m
               - name: Postgresql too many checkpoints requested
                 description: More than half of the checkpoints on {{ $labels.instance }} are unscheduled (requested) rather than timed, which usually means checkpoint_timeout or max_wal_size needs tuning.
                 query: "rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) / (rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) + rate(pg_stat_bgwriter_checkpoints_req_total[5m])) < 0.5 and (rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) + rate(pg_stat_bgwriter_checkpoints_req_total[5m])) > 0"
                 severity: warning
                 for: 5m
-              - name: Postgresql replication role changed
-                description: The replication role (primary/replica) of {{ $labels.instance }} has just changed, which usually indicates a failover happened. Verify whether this was expected.
-                query: "pg_replication_is_replica and changes(pg_replication_is_replica[1m]) > 0"
+
+              #
+              # Info, security, and config
+              #
+              - name: Postgresql SSL compression active
+                description: Database allows connections with SSL compression enabled. This may add significant jitter in replication delay. Replicas should turn off SSL compression via `sslcompression=0` in `recovery.conf`.
+                query: "sum by (instance) (pg_stat_ssl_compression) > 0"
                 severity: warning
-              - name: Postgresql max connections reached
-                description: PostgreSQL instance {{ $labels.instance }} has reached the maximum usable connection limit (max_connections minus superuser_reserved_connections). New client connections will be rejected until connections free up.
-                query: "sum by (instance, job, server) (pg_stat_activity_count) >= (min by (instance, job, server) (pg_settings_max_connections) - min by (instance, job, server) (pg_settings_superuser_reserved_connections))"
-                severity: critical
-                for: 1m
+                comments: |
+                  pg_stat_ssl_compression is not a default postgres_exporter metric and is only available on PostgreSQL 9.5-13 (removed in PG 14). See https://github.com/samber/awesome-prometheus-alerts/issues/289#issuecomment-1164842737
+              - name: Postgresql configuration changed
+                description: Postgres Database configuration change has occurred
+                query: '{__name__=~"pg_settings_.*",__name__!="pg_settings_transaction_read_only"} != ON(__name__, instance) {__name__=~"pg_settings_.*",__name__!="pg_settings_transaction_read_only"} OFFSET 5m'
+                severity: info
 
       - name: SQL Server
         logo: /images/services/sql-server.svg
@@ -1263,6 +1424,9 @@ groups:
             slug: ozarklake-mssql-exporter
             doc_url: https://github.com/Ozarklake/prometheus-mssql-exporter
             rules:
+              #
+              # Availability
+              #
               - name: SQL Server down
                 description: SQL server instance is down
                 query: mssql_up == 0
@@ -1270,6 +1434,10 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: SQL Server deadlock
                 description: SQL Server {{ $labels.instance }} is experiencing deadlocks ({{ $value }}/s)
                 query: mssql_deadlocks > 5
@@ -1283,6 +1451,9 @@ groups:
             slug: iamseth-oracledb-exporter
             doc_url: https://github.com/iamseth/oracledb_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Oracle DB down
                 description: Oracle Database instance is down on {{ $labels.instance }}
                 query: "oracledb_up == 0"
@@ -1290,6 +1461,24 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Oracle DB tablespace full (> 95%)
+                description: "Oracle Database tablespace {{ $labels.tablespace }} is critically full on {{ $labels.instance }} (current value: {{ $value }}%)"
+                query: "oracledb_tablespace_used_percent > 95"
+                severity: critical
+                for: 5m
+              - name: Oracle DB tablespace reaching capacity (> 85%)
+                description: "Oracle Database tablespace {{ $labels.tablespace }} is above 85% usage on {{ $labels.instance }} (current value: {{ $value }}%)"
+                query: "oracledb_tablespace_used_percent > 85"
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Oracle DB sessions reaching limit (> 85%)
                 description: "Oracle Database session utilization is above 85% on {{ $labels.instance }} (current value: {{ $value }}%)"
                 query: "oracledb_resource_current_utilization{resource_name=\"sessions\"} / oracledb_resource_limit_value{resource_name=\"sessions\"} * 100 > 85 and oracledb_resource_limit_value{resource_name=\"sessions\"} > 0"
@@ -1304,16 +1493,6 @@ groups:
                 for: 5m
                 comments: |
                   Threshold is workload-dependent. Adjust 85% to suit your environment.
-              - name: Oracle DB tablespace reaching capacity (> 85%)
-                description: "Oracle Database tablespace {{ $labels.tablespace }} is above 85% usage on {{ $labels.instance }} (current value: {{ $value }}%)"
-                query: "oracledb_tablespace_used_percent > 85"
-                severity: warning
-                for: 5m
-              - name: Oracle DB tablespace full (> 95%)
-                description: "Oracle Database tablespace {{ $labels.tablespace }} is critically full on {{ $labels.instance }} (current value: {{ $value }}%)"
-                query: "oracledb_tablespace_used_percent > 95"
-                severity: critical
-                for: 5m
               - name: Oracle DB high user rollbacks
                 description: "Oracle Database on {{ $labels.instance }} has a high rollback rate ({{ $value }}% of transactions are rolled back)"
                 query: "rate(oracledb_activity_user_rollbacks[5m]) / (rate(oracledb_activity_user_commits[5m]) + rate(oracledb_activity_user_rollbacks[5m])) * 100 > 20 and (rate(oracledb_activity_user_commits[5m]) + rate(oracledb_activity_user_rollbacks[5m])) > 0"
@@ -1343,6 +1522,9 @@ groups:
             slug: embedded-exporter-patroni
             doc_url: https://patroni.readthedocs.io/en/latest/rest_api.html?highlight=prometheus#monitoring-endpoint
             rules:
+              #
+              # Availability
+              #
               - name: Patroni has no Leader
                 description: A leader node (neither primary nor standby) cannot be found inside the cluster {{ $labels.scope }}
                 query: (max by (scope) (patroni_primary) < 1) and (max by (scope) (patroni_standby_leader) < 1)
@@ -1358,23 +1540,26 @@ groups:
             slug: spreaker-pgbouncer-exporter
             doc_url: https://github.com/spreaker/prometheus-pgbouncer-exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: PGBouncer max connections
+                description: The number of PGBouncer client connections has reached max_client_conn.
+                query: 'sum(pgbouncer_pools_client_active_connections + pgbouncer_pools_client_waiting_connections) >= pgbouncer_config_max_client_conn'
+                severity: critical
+              - name: PGBouncer server connection saturation critical
+                description: 'User connection capacity on {{ $labels.instance }} is above 90% ({{ $value | printf "%.2f" }}%), meaning PGBouncer is about to exhaust its configured max_user_connections limit.'
+                query: "100 * (sum without (database, user) (pgbouncer_pools_server_active_connections + pgbouncer_pools_server_idle_connections + pgbouncer_pools_server_used_connections) / clamp_min(pgbouncer_config_max_user_connections,1)) > 90"
+                severity: critical
+                for: 2m
               - name: PGBouncer active connections
                 description: PGBouncer pools are filling up
                 query: "pgbouncer_pools_server_active_connections > 200"
                 severity: warning
                 for: 2m
-              - name: PGBouncer max connections
-                description: The number of PGBouncer client connections has reached max_client_conn.
-                query: 'sum(pgbouncer_pools_client_active_connections + pgbouncer_pools_client_waiting_connections) >= pgbouncer_config_max_client_conn'
-                severity: critical
               - name: PGBouncer clients waiting for connection
                 description: "{{ $value }} client connections are queued in pool {{ $labels.database }}/{{ $labels.user }} waiting for a server connection, indicating pool exhaustion."
                 query: "pgbouncer_pools_client_waiting_connections > 20"
-                severity: warning
-                for: 2m
-              - name: PGBouncer high client wait time
-                description: The oldest queued client in pool {{ $labels.database }}/{{ $labels.user }} has been waiting {{ $value }}s for a server connection, which may indicate pool saturation or slow backend performance.
-                query: "pgbouncer_pools_client_maxwait_seconds > 15"
                 severity: warning
                 for: 2m
               - name: PGBouncer server connection saturation warning
@@ -1382,10 +1567,14 @@ groups:
                 query: "100 * (sum without (database, user) (pgbouncer_pools_server_active_connections + pgbouncer_pools_server_idle_connections + pgbouncer_pools_server_used_connections) / clamp_min(pgbouncer_config_max_user_connections,1)) > 80"
                 severity: warning
                 for: 2m
-              - name: PGBouncer server connection saturation critical
-                description: 'User connection capacity on {{ $labels.instance }} is above 90% ({{ $value | printf "%.2f" }}%), meaning PGBouncer is about to exhaust its configured max_user_connections limit.'
-                query: "100 * (sum without (database, user) (pgbouncer_pools_server_active_connections + pgbouncer_pools_server_idle_connections + pgbouncer_pools_server_used_connections) / clamp_min(pgbouncer_config_max_user_connections,1)) > 90"
-                severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: PGBouncer high client wait time
+                description: The oldest queued client in pool {{ $labels.database }}/{{ $labels.user }} has been waiting {{ $value }}s for a server connection, which may indicate pool saturation or slow backend performance.
+                query: "pgbouncer_pools_client_maxwait_seconds > 15"
+                severity: warning
                 for: 2m
 
       - name: Redis
@@ -1395,6 +1584,9 @@ groups:
             slug: oliver006-redis-exporter
             doc_url: https://github.com/oliver006/redis_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Redis down
                 description: Redis instance is down
                 query: "redis_up == 0"
@@ -1421,15 +1613,25 @@ groups:
                 description: Redis instance lost a slave
                 query: "delta(redis_connected_slaves[1m]) < 0"
                 severity: critical
-              - name: Redis cluster flapping
-                description: Changes have been detected in Redis replica connection. This can occur when replica nodes lose connection to the master and reconnect (a.k.a flapping).
-                query: "changes(redis_connected_slaves[1m]) > 1"
+              - name: Redis cluster state not ok
+                description: The Redis Cluster reports a non-ok state, meaning it is unable to serve queries, typically because hash slots are unassigned or too many nodes are down.
+                query: "redis_cluster_state == 0"
+                severity: critical
+                for: 5m
+              - name: Redis master link down
+                description: Redis replica {{ $labels.instance }} has lost its connection to master {{ $labels.master_host }}:{{ $labels.master_port }} and is no longer receiving updates.
+                query: "redis_master_link_up == 0"
                 severity: critical
                 for: 2m
-              - name: Redis missing backup
-                description: Redis has not been backed up for 48 hours
-                query: "time() - redis_rdb_last_save_timestamp_seconds > 60 * 60 * 48"
-                severity: critical
+              - name: Redis cluster slot fail
+                description: Some hash slots of the Redis Cluster are marked as FAIL, meaning part of the keyspace is unreachable and requires manual intervention or a failover.
+                query: "redis_cluster_slots_fail > 0"
+                severity: warning
+                for: 5m
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Redis out of system memory
                 description: Redis is running out of system memory (> 90%)
                 query: "redis_memory_used_bytes / redis_total_system_memory_bytes * 100 > 90 and redis_total_system_memory_bytes > 0"
@@ -1442,6 +1644,11 @@ groups:
                 query: "redis_memory_used_bytes / redis_memory_max_bytes * 100 > 90 and on(instance) redis_memory_max_bytes > 0"
                 severity: warning
                 for: 2m
+              - name: Redis cluster flapping
+                description: Changes have been detected in Redis replica connection. This can occur when replica nodes lose connection to the master and reconnect (a.k.a flapping).
+                query: "changes(redis_connected_slaves[1m]) > 1"
+                severity: critical
+                for: 2m
               - name: Redis too many connections
                 description: Redis is running out of connections (> 90% used)
                 query: "redis_connected_clients / redis_config_maxclients * 100 > 90 and redis_config_maxclients > 0"
@@ -1452,30 +1659,27 @@ groups:
                 query: "redis_connected_clients < 5"
                 severity: warning
                 for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Redis rejected connections
                 description: Some connections to Redis has been rejected
                 query: "increase(redis_rejected_connections_total[1m]) > 5"
                 severity: warning
-              - name: Redis cluster slot fail
-                description: Some hash slots of the Redis Cluster are marked as FAIL, meaning part of the keyspace is unreachable and requires manual intervention or a failover.
-                query: "redis_cluster_slots_fail > 0"
-                severity: warning
-                for: 5m
               - name: Redis cluster slot pfail
                 description: Some hash slots of the Redis Cluster are tentatively marked as PFAIL (possibly failing), an early warning sign of node problems before they escalate to a hard FAIL state.
                 query: "redis_cluster_slots_pfail > 0"
                 severity: warning
                 for: 5m
-              - name: Redis cluster state not ok
-                description: The Redis Cluster reports a non-ok state, meaning it is unable to serve queries, typically because hash slots are unassigned or too many nodes are down.
-                query: "redis_cluster_state == 0"
+
+              #
+              # Capacity and trend
+              #
+              - name: Redis missing backup
+                description: Redis has not been backed up for 48 hours
+                query: "time() - redis_rdb_last_save_timestamp_seconds > 60 * 60 * 48"
                 severity: critical
-                for: 5m
-              - name: Redis master link down
-                description: Redis replica {{ $labels.instance }} has lost its connection to master {{ $labels.master_host }}:{{ $labels.master_port }} and is no longer receiving updates.
-                query: "redis_master_link_up == 0"
-                severity: critical
-                for: 2m
 
       - name: Memcached
         logo: /images/services/memcached.svg
@@ -1484,6 +1688,9 @@ groups:
             slug: memcached-exporter
             doc_url: https://github.com/prometheus/memcached_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Memcached down
                 description: Memcached instance is down on {{ $labels.instance }}
                 query: "memcached_up == 0"
@@ -1491,21 +1698,10 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-              - name: Memcached connection limit approaching (> 80%)
-                description: "Memcached connection usage is above 80% on {{ $labels.instance }} (current value: {{ $value }}%)"
-                query: "(memcached_current_connections / memcached_max_connections * 100) > 80 and memcached_max_connections > 0"
-                severity: warning
-                for: 2m
-              - name: Memcached connection limit approaching (> 95%)
-                description: "Memcached connection usage is above 95% on {{ $labels.instance }} (current value: {{ $value }}%)"
-                query: "(memcached_current_connections / memcached_max_connections * 100) > 95 and memcached_max_connections > 0"
-                severity: critical
-                for: 2m
-              - name: Memcached out of memory errors
-                description: "Memcached is returning out-of-memory errors on {{ $labels.instance }} ({{ $value }} errors/s)"
-                query: "sum without (slab) (rate(memcached_slab_items_outofmemory_total[5m])) > 0.05"
-                severity: warning
-                for: 5m
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Memcached memory usage high (> 90%)
                 description: "Memcached memory usage is above 90% on {{ $labels.instance }} (current value: {{ $value }}%)"
                 query: "(memcached_current_bytes / memcached_limit_bytes * 100) > 90 and memcached_limit_bytes > 0"
@@ -1513,6 +1709,25 @@ groups:
                 for: 5m
                 comments: |
                   High memory usage is expected if the cache is well-utilized. This alert fires when it approaches the configured limit, which may cause evictions.
+              - name: Memcached connection limit approaching (> 95%)
+                description: "Memcached connection usage is above 95% on {{ $labels.instance }} (current value: {{ $value }}%)"
+                query: "(memcached_current_connections / memcached_max_connections * 100) > 95 and memcached_max_connections > 0"
+                severity: critical
+                for: 2m
+              - name: Memcached connection limit approaching (> 80%)
+                description: "Memcached connection usage is above 80% on {{ $labels.instance }} (current value: {{ $value }}%)"
+                query: "(memcached_current_connections / memcached_max_connections * 100) > 80 and memcached_max_connections > 0"
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Memcached out of memory errors
+                description: "Memcached is returning out-of-memory errors on {{ $labels.instance }} ({{ $value }} errors/s)"
+                query: "sum without (slab) (rate(memcached_slab_items_outofmemory_total[5m])) > 0.05"
+                severity: warning
+                for: 5m
               - name: Memcached high eviction rate
                 description: "Memcached is evicting items at a high rate on {{ $labels.instance }} ({{ $value }} evictions/s)"
                 query: "rate(memcached_items_evicted_total[5m]) > 10"
@@ -1545,6 +1760,9 @@ groups:
             slug: percona-mongodb-exporter
             doc_url: https://github.com/percona/mongodb_exporter
             rules:
+              #
+              # Availability
+              #
               - name: MongoDB Down
                 description: MongoDB instance is down
                 query: "mongodb_up == 0"
@@ -1559,6 +1777,39 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+              - name: MongoDB replica set has no primary
+                description: MongoDB replica set {{ $labels.job }} has no writable primary, so all writes will fail until a new primary is elected.
+                query: "sum(mongodb_ss_repl_isWritablePrimary) by (job) == 0"
+                severity: critical
+                for: 1m
+              - name: MongoDB replica set primary changed
+                description: MongoDB member {{ $labels.instance }} became the replica set primary in the last 10 minutes, which may indicate an election due to failover or instability.
+                query: "changes(mongodb_rs_myState[10m]) > 0 and mongodb_rs_myState == 1"
+                severity: warning
+                for: 2m
+                comments: |
+                  mongodb_rs_myState (this node's replica set state) is exposed in default mode.
+                  Restricted to == 1 (PRIMARY) so the alert fires once per election, from the new primary's series, instead of on every member state transition (e.g. a secondary's restart/resync cycle).
+                  Older exporters (or --compatible-mode) instead expose mongodb_mongod_replset_my_state.
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: MongoDB too many connections (Percona)
+                description: Too many connections (> 80%)
+                query: 'mongodb_ss_connections{conn_type="current"} / (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) * 100 > 80 and (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) > 0'
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: MongoDB replication headroom
+                description: MongoDB replication headroom is <= 0
+                query: 'sum(avg(mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
+                severity: critical
+                comments: |
+                  This query mixes old (mongodb_mongod_*) and new (mongodb_rs_*) metric names. It requires the Percona exporter to run with --compatible-mode to expose both.
               - name: MongoDB replication lag (Percona)
                 description: Mongodb replication lag is more than 30s
                 query: '(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"}) / 1000 > 30'
@@ -1566,12 +1817,6 @@ groups:
                 comments: |
                   mongodb_rs_members_optimeDate is exposed in default mode; its value is in milliseconds, hence the /1000 to compare seconds.
                   Older exporters (or --compatible-mode) instead expose a ready-made lag in seconds: mongodb_mongod_replset_member_replication_lag > 30.
-              - name: MongoDB replication headroom
-                description: MongoDB replication headroom is <= 0
-                query: 'sum(avg(mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (set) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
-                severity: critical
-                comments: |
-                  This query mixes old (mongodb_mongod_*) and new (mongodb_rs_*) metric names. It requires the Percona exporter to run with --compatible-mode to expose both.
               - name: MongoDB number cursors open (Percona)
                 description: Too many cursors opened by MongoDB for clients (> 10k)
                 query: 'mongodb_ss_metrics_cursor_open{csr_type="total"} > 10 * 1000'
@@ -1582,16 +1827,6 @@ groups:
                 query: "increase(mongodb_ss_metrics_cursor_timedOut[1m]) > 100"
                 severity: warning
                 for: 2m
-              - name: MongoDB too many connections (Percona)
-                description: Too many connections (> 80%)
-                query: 'mongodb_ss_connections{conn_type="current"} / (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) * 100 > 80 and (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) > 0'
-                severity: warning
-                for: 2m
-              - name: MongoDB replica set has no primary
-                description: MongoDB replica set {{ $labels.job }} has no writable primary, so all writes will fail until a new primary is elected.
-                query: "sum(mongodb_ss_repl_isWritablePrimary) by (job) == 0"
-                severity: critical
-                for: 1m
               - name: MongoDB WiredTiger read tickets exhausted
                 description: WiredTiger available read tickets on {{ $labels.instance }} have dropped to {{ $value }}, which causes read requests to queue and latency to spike.
                 query: 'mongodb_ss_wt_concurrentTransactions_available{txn_rw_type="read"} < 50'
@@ -1602,15 +1837,6 @@ groups:
                 query: 'mongodb_ss_wt_concurrentTransactions_available{txn_rw_type="write"} < 50'
                 severity: warning
                 for: 2m
-              - name: MongoDB replica set primary changed
-                description: MongoDB member {{ $labels.instance }} became the replica set primary in the last 10 minutes, which may indicate an election due to failover or instability.
-                query: "changes(mongodb_rs_myState[10m]) > 0 and mongodb_rs_myState == 1"
-                severity: warning
-                for: 2m
-                comments: |
-                  mongodb_rs_myState (this node's replica set state) is exposed in default mode.
-                  Restricted to == 1 (PRIMARY) so the alert fires once per election, from the new primary's series, instead of on every member state transition (e.g. a secondary's restart/resync cycle).
-                  Older exporters (or --compatible-mode) instead expose mongodb_mongod_replset_my_state.
               - name: MongoDB instance recently restarted
                 description: MongoDB instance {{ $labels.instance }} was restarted {{ $value }} seconds ago.
                 query: "mongodb_ss_uptime < 300"
@@ -1623,6 +1849,26 @@ groups:
             slug: dcu-mongodb-exporter
             doc_url: https://github.com/dcu/mongodb_exporter
             rules:
+              #
+              # Availability
+              #
+              - name: MongoDB replication Status 8
+                description: MongoDB Replication set member as seen from another member of the set, is unreachable
+                query: "mongodb_replset_member_state == 8"
+                severity: critical
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: MongoDB too many connections (DCU)
+                description: Too many connections (> 80%)
+                query: 'mongodb_connections{state="current"} / (mongodb_connections{state="current"} + mongodb_connections{state="available"}) * 100 > 80 and (mongodb_connections{state="current"} + mongodb_connections{state="available"}) > 0'
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: MongoDB replication lag (DCU)
                 description: Mongodb replication lag is more than 10s
                 query: 'avg(mongodb_replset_member_optime_date{state="PRIMARY"}) - avg(mongodb_replset_member_optime_date{state="SECONDARY"}) > 10'
@@ -1634,10 +1880,6 @@ groups:
               - name: MongoDB replication Status 6
                 description: MongoDB Replication set member as seen from another member of the set, is not yet known
                 query: "mongodb_replset_member_state == 6"
-                severity: critical
-              - name: MongoDB replication Status 8
-                description: MongoDB Replication set member as seen from another member of the set, is unreachable
-                query: "mongodb_replset_member_state == 8"
                 severity: critical
               - name: MongoDB replication Status 9
                 description: MongoDB Replication set member is actively performing a rollback. Data is not available for reads
@@ -1657,15 +1899,13 @@ groups:
                 query: "increase(mongodb_metrics_cursor_timed_out_total[1m]) > 100"
                 severity: warning
                 for: 2m
-              - name: MongoDB too many connections (DCU)
-                description: Too many connections (> 80%)
-                query: 'mongodb_connections{state="current"} / (mongodb_connections{state="current"} + mongodb_connections{state="available"}) * 100 > 80 and (mongodb_connections{state="current"} + mongodb_connections{state="available"}) > 0'
-                severity: warning
-                for: 2m
           - name: stefanprodan/mgob
             slug: stefanprodan-mgob-exporter
             doc_url: https://github.com/stefanprodan/mgob
             rules:
+              #
+              # Capacity and trend
+              #
               - name: Mgob backup failed
                 description: MongoDB backup has failed
                 query: 'changes(mgob_scheduler_backup_total{status="500"}[1h]) > 0'
@@ -1678,6 +1918,36 @@ groups:
             slug: prometheus-community-elasticsearch-exporter
             doc_url: https://github.com/prometheus-community/elasticsearch_exporter
             rules:
+              #
+              # Availability
+              #
+              - name: Elasticsearch Cluster Red
+                description: Elastic Cluster Red status
+                query: 'elasticsearch_cluster_health_status{color="red"} == 1'
+                severity: critical
+              - name: Elasticsearch Healthy Nodes
+                description: "Missing node in Elasticsearch cluster"
+                query: "elasticsearch_cluster_health_number_of_nodes < 3"
+                severity: critical
+                for: 1m
+                comments: |
+                  1m delay allows a restart without triggering an alert.
+              - name: Elasticsearch Healthy Data Nodes
+                description: "Missing data node in Elasticsearch cluster"
+                query: "elasticsearch_cluster_health_number_of_data_nodes < 3"
+                severity: critical
+                for: 1m
+                comments: |
+                  1m delay allows a restart without triggering an alert.
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Elasticsearch High CPU Usage
+                description: "OS or Elasticsearch process CPU usage on node {{ $labels.name }} is above 90% (current value: {{ $value }}%), which can cause thread starvation, GC pressure, and slow queries."
+                query: "elasticsearch_os_cpu_percent > 90 or elasticsearch_process_cpu_percent > 90"
+                severity: warning
+                for: 5m
               - name: Elasticsearch Heap Usage Too High
                 description: "The heap usage is over 90%"
                 query: '(elasticsearch_jvm_memory_used_bytes{area="heap"} / elasticsearch_jvm_memory_max_bytes{area="heap"}) * 100 > 90 and elasticsearch_jvm_memory_max_bytes{area="heap"} > 0'
@@ -1697,51 +1967,29 @@ groups:
                 query: "elasticsearch_filesystem_data_available_bytes / elasticsearch_filesystem_data_size_bytes * 100 < 20 and elasticsearch_filesystem_data_size_bytes > 0"
                 severity: warning
                 for: 2m
-              - name: Elasticsearch Cluster Red
-                description: Elastic Cluster Red status
-                query: 'elasticsearch_cluster_health_status{color="red"} == 1'
-                severity: critical
-              - name: Elasticsearch Cluster Yellow
-                description: Elastic Cluster Yellow status
-                query: 'elasticsearch_cluster_health_status{color="yellow"} == 1'
-                severity: warning
-              - name: Elasticsearch Healthy Nodes
-                description: "Missing node in Elasticsearch cluster"
-                query: "elasticsearch_cluster_health_number_of_nodes < 3"
-                severity: critical
-                for: 1m
-                comments: |
-                  1m delay allows a restart without triggering an alert.
-              - name: Elasticsearch Healthy Data Nodes
-                description: "Missing data node in Elasticsearch cluster"
-                query: "elasticsearch_cluster_health_number_of_data_nodes < 3"
-                severity: critical
-                for: 1m
-                comments: |
-                  1m delay allows a restart without triggering an alert.
-              - name: Elasticsearch relocating shards
-                description: "Elasticsearch is relocating shards"
-                query: "elasticsearch_cluster_health_relocating_shards > 0"
-                severity: info
-              - name: Elasticsearch relocating shards too long
-                description: "Elasticsearch has been relocating shards for 15min"
-                query: "elasticsearch_cluster_health_relocating_shards > 0"
-                severity: warning
-                for: 15m
-              - name: Elasticsearch initializing shards
-                description: "Elasticsearch is initializing shards"
-                query: "elasticsearch_cluster_health_initializing_shards > 0"
-                severity: info
-              - name: Elasticsearch initializing shards too long
-                description: "Elasticsearch has been initializing shards for 15 min"
-                query: "elasticsearch_cluster_health_initializing_shards > 0"
-                severity: warning
-                for: 15m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Elasticsearch unassigned shards
                 description: "Elasticsearch has unassigned shards"
                 query: "elasticsearch_cluster_health_unassigned_shards > 0"
                 severity: critical
                 for: 2m
+              - name: Elasticsearch Cluster Yellow
+                description: Elastic Cluster Yellow status
+                query: 'elasticsearch_cluster_health_status{color="yellow"} == 1'
+                severity: warning
+              - name: Elasticsearch relocating shards too long
+                description: "Elasticsearch has been relocating shards for 15min"
+                query: "elasticsearch_cluster_health_relocating_shards > 0"
+                severity: warning
+                for: 15m
+              - name: Elasticsearch initializing shards too long
+                description: "Elasticsearch has been initializing shards for 15 min"
+                query: "elasticsearch_cluster_health_initializing_shards > 0"
+                severity: warning
+                for: 15m
               - name: Elasticsearch pending tasks
                 description: "Elasticsearch has pending tasks. Cluster works slowly."
                 query: "elasticsearch_cluster_health_number_of_pending_tasks > 0"
@@ -1777,11 +2025,6 @@ groups:
                 query: "rate(elasticsearch_indices_search_query_time_seconds[1m]) / rate(elasticsearch_indices_search_query_total[1m]) > 1 and rate(elasticsearch_indices_search_query_total[1m]) > 0"
                 severity: warning
                 for: 5m
-              - name: Elasticsearch High CPU Usage
-                description: "OS or Elasticsearch process CPU usage on node {{ $labels.name }} is above 90% (current value: {{ $value }}%), which can cause thread starvation, GC pressure, and slow queries."
-                query: "elasticsearch_os_cpu_percent > 90 or elasticsearch_process_cpu_percent > 90"
-                severity: warning
-                for: 5m
               - name: Elasticsearch High Thread Pool Rejection Ratio
                 description: "The thread pool rejection ratio on Elasticsearch node {{ $labels.name }} (pool: {{ $labels.type }}) is above 5% (current value: {{ $value }}%), meaning the node cannot keep up with incoming requests and is dropping them."
                 query: "(rate(elasticsearch_thread_pool_rejected_count[5m]) / (rate(elasticsearch_thread_pool_rejected_count[5m]) + rate(elasticsearch_thread_pool_completed_count[5m]))) * 100 > 5 and (rate(elasticsearch_thread_pool_rejected_count[5m]) + rate(elasticsearch_thread_pool_completed_count[5m])) > 0"
@@ -1791,6 +2034,14 @@ groups:
                 description: The {{ $labels.breaker }} circuit breaker on Elasticsearch node {{ $labels.name }} has tripped in the last 5 minutes, meaning the node is rejecting operations to prevent a Java OutOfMemoryError.
                 query: "increase(elasticsearch_breakers_tripped[5m]) > 0"
                 severity: warning
+              - name: Elasticsearch relocating shards
+                description: "Elasticsearch is relocating shards"
+                query: "elasticsearch_cluster_health_relocating_shards > 0"
+                severity: info
+              - name: Elasticsearch initializing shards
+                description: "Elasticsearch is initializing shards"
+                query: "elasticsearch_cluster_health_initializing_shards > 0"
+                severity: info
 
       - name: OpenSearch
         logo: /images/services/opensearch.svg
@@ -1799,6 +2050,38 @@ groups:
             slug: opensearch-project-opensearch-prometheus-exporter
             doc_url: https://github.com/opensearch-project/opensearch-prometheus-exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: OpenSearch host CPU usage high
+                description: System CPU usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above 90%, which may cause search and indexing latency.
+                query: "sum by (cluster, instance, node) (opensearch_os_cpu_percent) > 90"
+                severity: warning
+                for: 5m
+              - name: OpenSearch process CPU usage high
+                description: CPU usage of the OpenSearch process on node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above 90%, indicating heavy load on the JVM process.
+                query: "sum by (cluster, instance, node) (opensearch_process_cpu_percent) > 90"
+                severity: warning
+                for: 5m
+              - name: OpenSearch high heap usage
+                description: "OpenSearch heap usage on cluster {{ $labels.cluster }} is too high"
+                query: opensearch_jvm_mem_heap_used_percent > 75
+                severity: warning
+                for: 10m
+              - name: OpenSearch disk high watermark reached
+                description: "Disk usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above the high watermark (90%): OpenSearch will start relocating existing shards away from this node."
+                query: "sum by (cluster, instance, node) (round((1 - (opensearch_fs_path_available_bytes / opensearch_fs_path_total_bytes)) * 100, 0.001)) > 90"
+                severity: critical
+                for: 5m
+              - name: OpenSearch disk low watermark reached
+                description: "Disk usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above the low watermark (85%): OpenSearch will stop allocating new shards to this node."
+                query: "sum by (cluster, instance, node) (round((1 - (opensearch_fs_path_available_bytes / opensearch_fs_path_total_bytes)) * 100, 0.001)) > 85"
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: OpenSearch is red
                 description: "OpenSearch cluster {{ $labels.cluster }} is RED: some primary shards are unassigned"
                 query: "opensearch_cluster_status == 2"
@@ -1809,11 +2092,6 @@ groups:
                 query: "opensearch_cluster_status == 1"
                 severity: warning
                 for: 5m
-              - name: OpenSearch high heap usage
-                description: "OpenSearch heap usage on cluster {{ $labels.cluster }} is too high"
-                query: opensearch_jvm_mem_heap_used_percent > 75
-                severity: warning
-                for: 10m
               - name: OpenSearch circuitbreaker tripped
                 description: "The circuitbreaker on OpenSearch cluster {{ $labels.cluster }} has tripped to prevent Java OutOfMemoryError"
                 query: "increase(opensearch_circuitbreaker_tripped_count[5m]) > 0"
@@ -1834,29 +2112,9 @@ groups:
                 query: "opensearch_cluster_shards_active_percent < 100.0"
                 severity: warning
                 for: 5m
-              - name: OpenSearch disk low watermark reached
-                description: "Disk usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above the low watermark (85%): OpenSearch will stop allocating new shards to this node."
-                query: "sum by (cluster, instance, node) (round((1 - (opensearch_fs_path_available_bytes / opensearch_fs_path_total_bytes)) * 100, 0.001)) > 85"
-                severity: warning
-                for: 5m
-              - name: OpenSearch disk high watermark reached
-                description: "Disk usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above the high watermark (90%): OpenSearch will start relocating existing shards away from this node."
-                query: "sum by (cluster, instance, node) (round((1 - (opensearch_fs_path_available_bytes / opensearch_fs_path_total_bytes)) * 100, 0.001)) > 90"
-                severity: critical
-                for: 5m
               - name: OpenSearch high bulk rejection rate
                 description: The ratio of rejected to completed bulk indexing requests on OpenSearch node {{ $labels.node }} is {{ $value }}%, meaning the node cannot keep up with bulk indexing throughput.
                 query: 'round((rate(opensearch_threadpool_threads_count{name="bulk",type="rejected"}[5m]) / rate(opensearch_threadpool_threads_count{name="bulk",type="completed"}[5m])) * 100, 0.001) > 5'
-                severity: warning
-                for: 5m
-              - name: OpenSearch host CPU usage high
-                description: System CPU usage on OpenSearch node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above 90%, which may cause search and indexing latency.
-                query: "sum by (cluster, instance, node) (opensearch_os_cpu_percent) > 90"
-                severity: warning
-                for: 5m
-              - name: OpenSearch process CPU usage high
-                description: CPU usage of the OpenSearch process on node {{ $labels.node }} (cluster {{ $labels.cluster }}) is above 90%, indicating heavy load on the JVM process.
-                query: "sum by (cluster, instance, node) (opensearch_process_cpu_percent) > 90"
                 severity: warning
                 for: 5m
 
@@ -1868,6 +2126,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://github.com/orgs/meilisearch/discussions/625
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Meilisearch index is empty
                 description: Meilisearch index {{ $labels.index }} has zero documents
                 query: "meilisearch_index_docs_count == 0"
@@ -1884,6 +2145,9 @@ groups:
             slug: instaclustr-cassandra-exporter
             doc_url: https://github.com/instaclustr/cassandra-exporter
             rules:
+              #
+              # Availability
+              #
               - name: "Cassandra Node is unavailable"
                 description: "Cassandra Node is unavailable - {{ $labels.cassandra_cluster }} {{ $labels.exported_endpoint }}"
                 query: "cassandra_endpoint_active < 1"
@@ -1891,25 +2155,10 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-              - name: "Cassandra many compaction tasks are pending"
-                description: "Many Cassandra compaction tasks are pending - {{ $labels.cassandra_cluster }}"
-                query: "cassandra_table_estimated_pending_compactions > 100"
-                severity: warning
-              - name: "Cassandra commitlog pending tasks (Instaclustr)"
-                description: "Cassandra commitlog pending tasks - {{ $labels.cassandra_cluster }}"
-                query: "cassandra_commit_log_pending_tasks > 15"
-                for: 2m
-                severity: warning
-              - name: "Cassandra compaction executor blocked tasks (Instaclustr)"
-                description: "Some Cassandra compaction executor tasks are blocked - {{ $labels.cassandra_cluster }}"
-                query: 'cassandra_thread_pool_blocked_tasks{pool="CompactionExecutor"} > 15'
-                for: 2m
-                severity: warning
-              - name: "Cassandra flush writer blocked tasks (Instaclustr)"
-                description: "Some Cassandra flush writer tasks are blocked - {{ $labels.cassandra_cluster }}"
-                query: 'cassandra_thread_pool_blocked_tasks{pool="MemtableFlushWriter"} > 15'
-                for: 2m
-                severity: warning
+
+              #
+              # Performance and errors (RED)
+              #
               - name: "Cassandra connection timeouts total (Instaclustr)"
                 description: "Some connection between nodes are ending in timeout - {{ $labels.cassandra_cluster }}"
                 query: "sum by (cassandra_cluster,instance) (rate(cassandra_client_request_timeouts_total[5m])) > 5"
@@ -1944,30 +2193,37 @@ groups:
                 query: 'increase(cassandra_client_request_failures_total{operation="read"}[1m]) > 5'
                 for: 2m
                 severity: critical
+              - name: "Cassandra many compaction tasks are pending"
+                description: "Many Cassandra compaction tasks are pending - {{ $labels.cassandra_cluster }}"
+                query: "cassandra_table_estimated_pending_compactions > 100"
+                severity: warning
+              - name: "Cassandra commitlog pending tasks (Instaclustr)"
+                description: "Cassandra commitlog pending tasks - {{ $labels.cassandra_cluster }}"
+                query: "cassandra_commit_log_pending_tasks > 15"
+                for: 2m
+                severity: warning
+              - name: "Cassandra compaction executor blocked tasks (Instaclustr)"
+                description: "Some Cassandra compaction executor tasks are blocked - {{ $labels.cassandra_cluster }}"
+                query: 'cassandra_thread_pool_blocked_tasks{pool="CompactionExecutor"} > 15'
+                for: 2m
+                severity: warning
+              - name: "Cassandra flush writer blocked tasks (Instaclustr)"
+                description: "Some Cassandra flush writer tasks are blocked - {{ $labels.cassandra_cluster }}"
+                query: 'cassandra_thread_pool_blocked_tasks{pool="MemtableFlushWriter"} > 15'
+                for: 2m
+                severity: warning
 
           - name: criteo/cassandra_exporter
             slug: criteo-cassandra-exporter
             doc_url: https://github.com/criteo/cassandra_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Cassandra hints count
                 description: Cassandra hints count has changed on {{ $labels.instance }} some nodes may go down
                 query: 'changes(cassandra_stats{name="org:apache:cassandra:metrics:storage:totalhints:count"}[1m]) > 3'
                 severity: critical
-              - name: Cassandra compaction task pending
-                description: Many Cassandra compaction tasks are pending. You might need to increase I/O capacity by adding nodes to the cluster.
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:compaction:pendingtasks:value"} > 100'
-                severity: warning
-                for: 2m
-              - name: Cassandra viewwrite latency
-                description: High viewwrite latency on {{ $labels.instance }} cassandra node
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:clientrequest:viewwrite:viewwritelatency:99thpercentile"} > 100000'
-                severity: warning
-                for: 2m
-              - name: Cassandra authentication failures
-                description: Increase of Cassandra authentication failures
-                query: 'delta(cassandra_stats{name="org:apache:cassandra:metrics:client:authfailure:count"}[1m]) > 5'
-                severity: warning
-                for: 2m
               - name: Cassandra node down
                 description: Cassandra node down
                 query: 'sum(cassandra_stats{name="org:apache:cassandra:net:failuredetector:downendpointcount"}) by (service,group,cluster,env) > 0'
@@ -1975,31 +2231,10 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-              - name: Cassandra commitlog pending tasks (Criteo)
-                description: Unexpected number of Cassandra commitlog pending tasks
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:commitlog:pendingtasks:value"} > 15'
-                severity: warning
-                for: 2m
-              - name: Cassandra compaction executor blocked tasks (Criteo)
-                description: Some Cassandra compaction executor tasks are blocked
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:currentlyblockedtasks:count"} > 0'
-                severity: warning
-                for: 2m
-              - name: Cassandra flush writer blocked tasks (Criteo)
-                description: Some Cassandra flush writer tasks are blocked
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:memtableflushwriter:currentlyblockedtasks:count"} > 0'
-                severity: warning
-                for: 2m
-              - name: Cassandra repair pending tasks
-                description: Some Cassandra repair tasks are pending
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:antientropystage:pendingtasks:value"} > 2'
-                severity: warning
-                for: 2m
-              - name: Cassandra repair blocked tasks
-                description: Some Cassandra repair tasks are blocked
-                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:antientropystage:currentlyblockedtasks:count"} > 0'
-                severity: warning
-                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Cassandra connection timeouts total (Criteo)
                 description: Some connection between nodes are ending in timeout
                 query: 'delta(cassandra_stats{name="org:apache:cassandra:metrics:connection:totaltimeouts:count"}[1m]) > 5'
@@ -2029,6 +2264,41 @@ groups:
                 description: A lot of read failures encountered. A read failure is a non-timeout exception encountered during a read request. Examine the reason map to find to the root cause. The most common cause for this type of error is when batch sizes are too large.
                 query: 'cassandra_stats{name="org:apache:cassandra:metrics:clientrequest:read:failures:oneminuterate"} > 0.05'
                 severity: critical
+              - name: Cassandra compaction task pending
+                description: Many Cassandra compaction tasks are pending. You might need to increase I/O capacity by adding nodes to the cluster.
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:compaction:pendingtasks:value"} > 100'
+                severity: warning
+                for: 2m
+              - name: Cassandra viewwrite latency
+                description: High viewwrite latency on {{ $labels.instance }} cassandra node
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:clientrequest:viewwrite:viewwritelatency:99thpercentile"} > 100000'
+                severity: warning
+                for: 2m
+              - name: Cassandra commitlog pending tasks (Criteo)
+                description: Unexpected number of Cassandra commitlog pending tasks
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:commitlog:pendingtasks:value"} > 15'
+                severity: warning
+                for: 2m
+              - name: Cassandra compaction executor blocked tasks (Criteo)
+                description: Some Cassandra compaction executor tasks are blocked
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:currentlyblockedtasks:count"} > 0'
+                severity: warning
+                for: 2m
+              - name: Cassandra flush writer blocked tasks (Criteo)
+                description: Some Cassandra flush writer tasks are blocked
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:memtableflushwriter:currentlyblockedtasks:count"} > 0'
+                severity: warning
+                for: 2m
+              - name: Cassandra repair pending tasks
+                description: Some Cassandra repair tasks are pending
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:antientropystage:pendingtasks:value"} > 2'
+                severity: warning
+                for: 2m
+              - name: Cassandra repair blocked tasks
+                description: Some Cassandra repair tasks are blocked
+                query: 'cassandra_stats{name="org:apache:cassandra:metrics:threadpools:internal:antientropystage:currentlyblockedtasks:count"} > 0'
+                severity: warning
+                for: 2m
               - name: Cassandra cache hit rate key cache
                 description: Key cache hit rate is below 85%
                 query: 'cassandra_stats{name="org:apache:cassandra:metrics:cache:keycache:hitrate:value"} < .85'
@@ -2037,6 +2307,15 @@ groups:
                 comments: |
                   A low key cache hit rate increases disk I/O. Threshold is workload-dependent — adjust based on your data access patterns.
 
+              #
+              # Info, security, and config
+              #
+              - name: Cassandra authentication failures
+                description: Increase of Cassandra authentication failures
+                query: 'delta(cassandra_stats{name="org:apache:cassandra:metrics:client:authfailure:count"}[1m]) > 5'
+                severity: warning
+                for: 2m
+
       - name: Clickhouse
         logo: /images/services/clickhouse.svg
         exporters:
@@ -2044,6 +2323,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://clickhouse.com/docs/en/operations/system-tables/metrics
             rules:
+              #
+              # Availability
+              #
               - name: ClickHouse node down
                 description: "No metrics received from ClickHouse exporter for over 2 minutes."
                 query: 'up{job="clickhouse"} == 0'
@@ -2051,75 +2333,16 @@ groups:
                 for: 2m
                 comments: |
                   Adjust the job label to match your Prometheus configuration.
-              - name: ClickHouse Memory Usage Critical
-                description: "Memory usage is critically high, over 90%."
-                query: "ClickHouseAsyncMetrics_CGroupMemoryUsed / ClickHouseAsyncMetrics_CGroupMemoryTotal * 100 > 90 and ClickHouseAsyncMetrics_CGroupMemoryTotal > 0"
-                severity: critical
-                for: 5m
-              - name: ClickHouse Memory Usage Warning
-                description: "Memory usage is over 80%."
-                query: "ClickHouseAsyncMetrics_CGroupMemoryUsed / ClickHouseAsyncMetrics_CGroupMemoryTotal * 100 > 80 and ClickHouseAsyncMetrics_CGroupMemoryTotal > 0"
-                severity: warning
-                for: 5m
-              - name: ClickHouse Disk Space Low on Default
-                description: "Disk space on default is below 20%."
-                query: "ClickHouseAsyncMetrics_DiskAvailable_default / (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) * 100 < 20 and (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) > 0"
-                severity: warning
-                for: 2m
-              - name: ClickHouse Disk Space Critical on Default
-                description: "Disk space on default disk is critically low, below 10%."
-                query: "ClickHouseAsyncMetrics_DiskAvailable_default / (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) * 100 < 10 and (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) > 0"
-                severity: critical
-                for: 2m
-              - name: ClickHouse Disk Space Low on Backups
-                description: "Disk space on backups is below 20%."
-                query: "ClickHouseAsyncMetrics_DiskAvailable_backups / (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) * 100 < 20 and (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) > 0"
-                severity: warning
-                for: 2m
-              - name: ClickHouse Replica Errors
-                description: "Critical replica errors detected, either all replicas are stale or lost."
-                query: "increase(ClickHouseErrorMetric_ALL_REPLICAS_ARE_STALE[5m]) > 0 or increase(ClickHouseErrorMetric_ALL_REPLICAS_LOST[5m]) > 0"
-                severity: critical
-                for: 3m
-
               - name: ClickHouse No Available Replicas
                 description: "No available replicas in ClickHouse."
                 query: "increase(ClickHouseErrorMetric_NO_AVAILABLE_REPLICA[5m]) > 0"
                 severity: critical
                 for: 3m
-
               - name: ClickHouse No Live Replicas
                 description: "There are too few live replicas available, risking data loss and service disruption."
                 query: "increase(ClickHouseErrorMetric_TOO_FEW_LIVE_REPLICAS[5m]) > 0"
                 severity: critical
                 for: 3m
-              - name: ClickHouse replication lag
-                description: Replication lag between the freshest replicated data part and the most stale part still to be replicated is high, meaning reads from lagging replicas may return stale data.
-                query: "ClickHouseAsyncMetrics_ReplicasMaxAbsoluteDelay > 300"
-                severity: warning
-                for: 5m
-              - name: ClickHouse too many parts per partition
-                description: The number of data parts per partition on {{ $labels.instance }} is high, an early warning sign of merge pressure before ClickHouse starts rejecting or delaying INSERTs.
-                query: "ClickHouseAsyncMetrics_MaxPartCountForPartition > 100"
-                severity: warning
-                for: 5m
-              - name: ClickHouse readonly replica
-                description: A Replicated table on {{ $labels.instance }} is stuck in readonly mode, usually after losing its ZooKeeper session or starting up without ZooKeeper available.
-                query: "ClickHouseMetrics_ReadonlyReplica > 0"
-                severity: critical
-              - name: ClickHouse replicated data loss
-                description: A wanted data part does not exist on any replica, including offline ones, indicating actual data loss on {{ $labels.instance }}.
-                query: "increase(ClickHouseProfileEvents_ReplicatedDataLoss[1m]) > 0"
-                severity: critical
-                for: 1m
-
-              - name: ClickHouse High TCP Connections
-                description: "High number of TCP connections, indicating heavy client or inter-cluster communication."
-                query: "ClickHouseMetrics_TCPConnection > 400"
-                severity: warning
-                for: 5m
-                comments: |
-                  Please replace the threshold with an appropriate value
               - name: ClickHouse Interserver Connection Issues
                 description: "High number of interserver connections may indicate replication or distributed query handling issues."
                 query: "ClickHouseMetrics_InterserverConnection > 50"
@@ -2132,16 +2355,82 @@ groups:
                 query: "ClickHouseMetrics_ZooKeeperSession != 1"
                 severity: warning
                 for: 3m
-              - name: ClickHouse Authentication Failures
-                description: "Authentication failures detected, indicating potential security issues or misconfiguration."
-                query: "increase(ClickHouseErrorMetric_AUTHENTICATION_FAILED[5m]) > 3"
-                severity: info
 
-              - name: ClickHouse Access Denied Errors
-                description: "Access denied errors have been logged, which could indicate permission issues or unauthorized access attempts."
-                query: "increase(ClickHouseErrorMetric_RESOURCE_ACCESS_DENIED[5m]) > 3"
-                severity: info
+              #
+              # Resource saturation (USE)
+              #
+              - name: ClickHouse Memory Usage Critical
+                description: "Memory usage is critically high, over 90%."
+                query: "ClickHouseAsyncMetrics_CGroupMemoryUsed / ClickHouseAsyncMetrics_CGroupMemoryTotal * 100 > 90 and ClickHouseAsyncMetrics_CGroupMemoryTotal > 0"
+                severity: critical
+                for: 5m
+              - name: ClickHouse Memory Usage Warning
+                description: "Memory usage is over 80%."
+                query: "ClickHouseAsyncMetrics_CGroupMemoryUsed / ClickHouseAsyncMetrics_CGroupMemoryTotal * 100 > 80 and ClickHouseAsyncMetrics_CGroupMemoryTotal > 0"
+                severity: warning
+                for: 5m
+              - name: ClickHouse Disk Space Critical on Default
+                description: "Disk space on default disk is critically low, below 10%."
+                query: "ClickHouseAsyncMetrics_DiskAvailable_default / (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) * 100 < 10 and (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) > 0"
+                severity: critical
+                for: 2m
+              - name: ClickHouse Disk Space Low on Default
+                description: "Disk space on default is below 20%."
+                query: "ClickHouseAsyncMetrics_DiskAvailable_default / (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) * 100 < 20 and (ClickHouseAsyncMetrics_DiskAvailable_default + ClickHouseAsyncMetrics_DiskUsed_default) > 0"
+                severity: warning
+                for: 2m
+              - name: ClickHouse too many parts per partition
+                description: The number of data parts per partition on {{ $labels.instance }} is high, an early warning sign of merge pressure before ClickHouse starts rejecting or delaying INSERTs.
+                query: "ClickHouseAsyncMetrics_MaxPartCountForPartition > 100"
+                severity: warning
+                for: 5m
+              - name: ClickHouse high network usage
+                description: High network usage. ClickHouse network usage exceeds 100MB/s.
+                query: "rate(ClickHouseProfileEvents_NetworkSendBytes[1m]) > 100*1024*1024 or rate(ClickHouseProfileEvents_NetworkReceiveBytes[1m]) > 100*1024*1024"
+                severity: warning
+                for: 2m
+                comments: |
+                  Please replace the threshold with an appropriate value
+              - name: ClickHouse High TCP Connections
+                description: "High number of TCP connections, indicating heavy client or inter-cluster communication."
+                query: "ClickHouseMetrics_TCPConnection > 400"
+                severity: warning
+                for: 5m
+                comments: |
+                  Please replace the threshold with an appropriate value
 
+              #
+              # Performance and errors (RED)
+              #
+              - name: ClickHouse Replica Errors
+                description: "Critical replica errors detected, either all replicas are stale or lost."
+                query: "increase(ClickHouseErrorMetric_ALL_REPLICAS_ARE_STALE[5m]) > 0 or increase(ClickHouseErrorMetric_ALL_REPLICAS_LOST[5m]) > 0"
+                severity: critical
+                for: 3m
+              - name: ClickHouse readonly replica
+                description: A Replicated table on {{ $labels.instance }} is stuck in readonly mode, usually after losing its ZooKeeper session or starting up without ZooKeeper available.
+                query: "ClickHouseMetrics_ReadonlyReplica > 0"
+                severity: critical
+              - name: ClickHouse replicated data loss
+                description: A wanted data part does not exist on any replica, including offline ones, indicating actual data loss on {{ $labels.instance }}.
+                query: "increase(ClickHouseProfileEvents_ReplicatedDataLoss[1m]) > 0"
+                severity: critical
+                for: 1m
+              - name: ClickHouse zookeeper hardware exception
+                description: "Zookeeper hardware exception: network issues communicating with ZooKeeper"
+                query: "increase(ClickHouseProfileEvents_ZooKeeperHardwareExceptions[1m]) > 0"
+                severity: critical
+                for: 1m
+              - name: ClickHouse distributed rejected inserts
+                description: "INSERTs into Distributed tables rejected due to pending bytes limit."
+                query: "increase(ClickHouseProfileEvents_DistributedRejectedInserts[5m]) > 3"
+                severity: critical
+                for: 2m
+              - name: ClickHouse replication lag
+                description: Replication lag between the freshest replicated data part and the most stale part still to be replicated is high, meaning reads from lagging replicas may return stale data.
+                query: "ClickHouseAsyncMetrics_ReplicasMaxAbsoluteDelay > 300"
+                severity: warning
+                for: 5m
               - name: ClickHouse rejected insert queries
                 description: "INSERTs rejected due to too many active data parts. Reduce insert frequency."
                 query: "increase(ClickHouseProfileEvents_RejectedInserts[1m]) > 2"
@@ -2152,23 +2441,27 @@ groups:
                 query: "increase(ClickHouseProfileEvents_DelayedInserts[5m]) > 10"
                 severity: warning
                 for: 2m
-              - name: ClickHouse zookeeper hardware exception
-                description: "Zookeeper hardware exception: network issues communicating with ZooKeeper"
-                query: "increase(ClickHouseProfileEvents_ZooKeeperHardwareExceptions[1m]) > 0"
-                severity: critical
-                for: 1m
-              - name: ClickHouse high network usage
-                description: High network usage. ClickHouse network usage exceeds 100MB/s.
-                query: "rate(ClickHouseProfileEvents_NetworkSendBytes[1m]) > 100*1024*1024 or rate(ClickHouseProfileEvents_NetworkReceiveBytes[1m]) > 100*1024*1024"
+
+              #
+              # Capacity and trend
+              #
+              - name: ClickHouse Disk Space Low on Backups
+                description: "Disk space on backups is below 20%."
+                query: "ClickHouseAsyncMetrics_DiskAvailable_backups / (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) * 100 < 20 and (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) > 0"
                 severity: warning
                 for: 2m
-                comments: |
-                  Please replace the threshold with an appropriate value
-              - name: ClickHouse distributed rejected inserts
-                description: "INSERTs into Distributed tables rejected due to pending bytes limit."
-                query: "increase(ClickHouseProfileEvents_DistributedRejectedInserts[5m]) > 3"
-                severity: critical
-                for: 2m
+
+              #
+              # Info, security, and config
+              #
+              - name: ClickHouse Authentication Failures
+                description: "Authentication failures detected, indicating potential security issues or misconfiguration."
+                query: "increase(ClickHouseErrorMetric_AUTHENTICATION_FAILED[5m]) > 3"
+                severity: info
+              - name: ClickHouse Access Denied Errors
+                description: "Access denied errors have been logged, which could indicate permission issues or unauthorized access attempts."
+                query: "increase(ClickHouseErrorMetric_RESOURCE_ACCESS_DENIED[5m]) > 3"
+                severity: info
 
       - name: CouchDB
         logo: /images/services/couchdb.svg
@@ -2177,23 +2470,23 @@ groups:
             slug: gesellix-couchdb-prometheus-exporter
             doc_url: https://github.com/gesellix/couchdb-prometheus-exporter
             rules:
+              #
+              # Availability
+              #
               - name: CouchDB node down
                 description: CouchDB node is not responding (node_up metric is 0) for more than 2 minutes
                 query: "couchdb_httpd_node_up == 0 or couchdb_httpd_up == 0"
                 severity: critical
                 for: 2m
+
+              #
+              # Resource saturation (USE)
+              #
               - name: CouchDB atom memory usage critical
                 description: Atom memory usage is above 90% of limit
                 query: "couchdb_erlang_memory_atom_used > 0.9 * couchdb_erlang_memory_atom"
                 severity: critical
                 for: 5m
-              - name: CouchDB open databases critical
-                description: Number of open databases exceeds 90% of node capacity
-                query: "couchdb_httpd_open_databases > 0.9 * 1000"
-                severity: critical
-                for: 5m
-                comments: |
-                  The default max_dbs_open is 500. Adjust the threshold (currently 0.9 * 1000) to match your max_dbs_open setting.
               - name: CouchDB open OS files critical
                 description: CouchDB is using more than 90% of allowed OS file descriptors, may fail to open new files
                 query: "couchdb_httpd_open_os_files > 0.9 * 65535"
@@ -2201,6 +2494,22 @@ groups:
                 for: 5m
                 comments: |
                   Adjust 65535 to match your system's file descriptor limit (ulimit -n).
+              - name: CouchDB file descriptors high
+                description: Process is using more than 85% of allowed file descriptors
+                query: "process_open_fds / process_max_fds > 0.85 and process_max_fds > 0"
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: CouchDB open databases critical
+                description: Number of open databases exceeds 90% of node capacity
+                query: "couchdb_httpd_open_databases > 0.9 * 1000"
+                severity: critical
+                for: 5m
+                comments: |
+                  The default max_dbs_open is 500. Adjust the threshold (currently 0.9 * 1000) to match your max_dbs_open setting.
               - name: CouchDB 5xx error ratio high
                 description: More than 5% of HTTP requests are returning 5xx errors
                 query: "rate(couchdb_httpd_status_codes{code=~\"5..\"}[5m]) / rate(couchdb_httpd_requests[5m]) > 0.05 and rate(couchdb_httpd_requests[5m]) > 0"
@@ -2210,21 +2519,6 @@ groups:
                 description: Temporary view read rate exceeds 100 reads/sec, high risk of performance degradation
                 query: "rate(couchdb_httpd_temporary_view_reads[5m]) > 100"
                 severity: critical
-                for: 5m
-              - name: CouchDB Mango queries scanning too many docs
-                description: Some Mango queries are scanning too many documents, consider adding indexes
-                query: "rate(couchdb_mango_too_many_docs_scanned[5m]) > 50"
-                severity: warning
-                for: 5m
-              - name: CouchDB Mango queries failed due to invalid index
-                description: Some Mango queries failed to execute because the index was missing or invalid
-                query: "rate(couchdb_mango_query_invalid_index[5m]) > 5"
-                severity: warning
-                for: 5m
-              - name: CouchDB Mango docs examined high
-                description: High number of documents examined per Mango queries, consider indexing
-                query: "rate(couchdb_mango_docs_examined[5m]) > 1000"
-                severity: warning
                 for: 5m
               - name: CouchDB Replicator manager died
                 description: Replication manager process has crashed
@@ -2251,31 +2545,11 @@ groups:
                 query: "couchdb_replicator_cluster_is_stable == 0"
                 severity: critical
                 for: 2m
-              - name: CouchDB replication read failures
-                description: Replication changes feed has failed reads more than 5 times in 5 minutes
-                query: "increase(couchdb_replicator_changes_read_failures[5m]) > 5"
-                severity: warning
-                for: 5m
-              - name: CouchDB file descriptors high
-                description: Process is using more than 85% of allowed file descriptors
-                query: "process_open_fds / process_max_fds > 0.85 and process_max_fds > 0"
-                severity: warning
-                for: 5m
               - name: CouchDB critical log entries
                 description: Critical or error log entries detected in the last 5 minutes
                 query: "increase(couchdb_server_couch_log{level=~\"error|critical\"}[5m]) > 5"
                 severity: critical
                 for: 1m
-              - name: CouchDB 4xx error rate high
-                description: CouchDB returned more than 5 4xx HTTP responses in the last 5 minutes, which may indicate client-side issues such as bad requests, authentication failures, or document conflicts.
-                query: 'increase(couchdb_httpd_status_codes{code=~"4.."}[5m]) > 5'
-                severity: warning
-                for: 5m
-              - name: CouchDB Replicator jobs pending
-                description: More than 10 replicator jobs are pending, which may mean replication is falling behind.
-                query: 'couchdb_replicator_jobs{metric="pending"} > 10'
-                severity: warning
-                for: 5m
               - name: CouchDB Replicator jobs crashing
                 description: Replicator jobs are crashing, indicating replication tasks are failing unexpectedly.
                 query: 'increase(couchdb_replicator_jobs{metric="crashes"}[5m]) > 0'
@@ -2291,15 +2565,45 @@ groups:
                 query: 'increase(couchdb_replicator_connections{metric="worker_crashes"}[5m]) > 0'
                 severity: critical
                 for: 1m
-              - name: CouchDB request latency high
-                description: Average CouchDB request time is above 500ms, indicating degraded performance.
-                query: 'couchdb_httpd_request_time{metric="ArithmeticMean"} > 500'
-                severity: warning
-                for: 5m
               - name: CouchDB request latency critical
                 description: Average CouchDB request time is above 1000ms, indicating severe performance degradation.
                 query: 'couchdb_httpd_request_time{metric="ArithmeticMean"} > 1000'
                 severity: critical
+                for: 5m
+              - name: CouchDB Mango queries scanning too many docs
+                description: Some Mango queries are scanning too many documents, consider adding indexes
+                query: "rate(couchdb_mango_too_many_docs_scanned[5m]) > 50"
+                severity: warning
+                for: 5m
+              - name: CouchDB Mango queries failed due to invalid index
+                description: Some Mango queries failed to execute because the index was missing or invalid
+                query: "rate(couchdb_mango_query_invalid_index[5m]) > 5"
+                severity: warning
+                for: 5m
+              - name: CouchDB Mango docs examined high
+                description: High number of documents examined per Mango queries, consider indexing
+                query: "rate(couchdb_mango_docs_examined[5m]) > 1000"
+                severity: warning
+                for: 5m
+              - name: CouchDB replication read failures
+                description: Replication changes feed has failed reads more than 5 times in 5 minutes
+                query: "increase(couchdb_replicator_changes_read_failures[5m]) > 5"
+                severity: warning
+                for: 5m
+              - name: CouchDB 4xx error rate high
+                description: CouchDB returned more than 5 4xx HTTP responses in the last 5 minutes, which may indicate client-side issues such as bad requests, authentication failures, or document conflicts.
+                query: 'increase(couchdb_httpd_status_codes{code=~"4.."}[5m]) > 5'
+                severity: warning
+                for: 5m
+              - name: CouchDB Replicator jobs pending
+                description: More than 10 replicator jobs are pending, which may mean replication is falling behind.
+                query: 'couchdb_replicator_jobs{metric="pending"} > 10'
+                severity: warning
+                for: 5m
+              - name: CouchDB request latency high
+                description: Average CouchDB request time is above 500ms, indicating degraded performance.
+                query: 'couchdb_httpd_request_time{metric="ArithmeticMean"} > 500'
+                severity: warning
                 for: 5m
 
       - name: Solr
@@ -2309,15 +2613,41 @@ groups:
             slug: embedded-exporter
             doc_url: https://solr.apache.org/guide/8_11/monitoring-solr-with-prometheus-and-grafana.html
             rules:
+              #
+              # Availability
+              #
+              - name: Solr shard has no leader
+                description: Solr collection {{ $labels.collection }} shard {{ $labels.shard }} has no elected leader and cannot accept writes until a new leader is elected.
+                query: "max by (collection, shard) (solr_collections_shard_leader) < 1"
+                severity: critical
+                for: 2m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Solr high JVM heap usage
+                description: Solr node {{ $labels.base_url }} is using more than 90% of its JVM heap, which can lead to node instability, stop-the-world GC pauses, or OutOfMemory crashes.
+                query: 'sum by (base_url) (solr_metrics_jvm_memory_heap_bytes{item="used"}) / sum by (base_url) (solr_metrics_jvm_memory_heap_bytes{item="max"}) > 0.9'
+                severity: warning
+                for: 5m
+              - name: Solr disk space very low
+                description: Solr node {{ $labels.base_url }} has less than 10% usable disk space remaining, an imminent risk of index corruption or write failures.
+                query: 'min by (base_url) (solr_metrics_core_fs_bytes{item="usableSpace"}) / max by (base_url) (solr_metrics_core_fs_bytes{item="totalSpace"}) <= 0.1'
+                severity: critical
+                for: 10m
+              - name: Solr disk space low
+                description: Solr node {{ $labels.base_url }} has less than 20% usable disk space remaining, risking index corruption if it fills up.
+                query: 'min by (base_url) (solr_metrics_core_fs_bytes{item="usableSpace"}) / max by (base_url) (solr_metrics_core_fs_bytes{item="totalSpace"}) <= 0.2'
+                severity: warning
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Solr update errors
                 description: Solr collection {{ $labels.collection }} has failed updates for replica {{ $labels.replica }} on {{ $labels.base_url }}.
                 query: "increase(solr_metrics_core_update_handler_errors_total[1m]) > 1"
                 severity: critical
-              - name: Solr query errors
-                description: Solr has increased query errors in collection {{ $labels.collection }} for replica {{ $labels.replica }} on {{ $labels.base_url }}.
-                query: 'increase(solr_metrics_core_errors_total{category="QUERY"}[1m]) > 1'
-                severity: warning
-                for: 5m
               - name: Solr replication errors
                 description: Solr collection {{ $labels.collection }} has replication errors for replica {{ $labels.replica }} on {{ $labels.base_url }}.
                 query: 'increase(solr_metrics_core_errors_total{category="REPLICATION"}[1m]) > 1'
@@ -2326,36 +2656,21 @@ groups:
                 description: Solr collection {{ $labels.collection }} has less than two live nodes for replica {{ $labels.replica }} on {{ $labels.base_url }}.
                 query: "solr_collections_live_nodes < 2"
                 severity: critical
-              - name: Solr shard has no leader
-                description: Solr collection {{ $labels.collection }} shard {{ $labels.shard }} has no elected leader and cannot accept writes until a new leader is elected.
-                query: "max by (collection, shard) (solr_collections_shard_leader) < 1"
-                severity: critical
-                for: 2m
               - name: Solr shard has no active replica
                 description: Solr collection {{ $labels.collection }} shard {{ $labels.shard }} has no active replicas, causing a complete read/write outage for that shard.
                 query: 'count by (collection, shard) (solr_collections_replica_state{state="active"}) < 1'
                 severity: critical
                 for: 5m
-              - name: Solr high JVM heap usage
-                description: Solr node {{ $labels.base_url }} is using more than 90% of its JVM heap, which can lead to node instability, stop-the-world GC pauses, or OutOfMemory crashes.
-                query: 'sum by (base_url) (solr_metrics_jvm_memory_heap_bytes{item="used"}) / sum by (base_url) (solr_metrics_jvm_memory_heap_bytes{item="max"}) > 0.9'
-                severity: warning
-                for: 5m
-              - name: Solr disk space low
-                description: Solr node {{ $labels.base_url }} has less than 20% usable disk space remaining, risking index corruption if it fills up.
-                query: 'min by (base_url) (solr_metrics_core_fs_bytes{item="usableSpace"}) / max by (base_url) (solr_metrics_core_fs_bytes{item="totalSpace"}) <= 0.2'
-                severity: warning
-                for: 10m
-              - name: Solr disk space very low
-                description: Solr node {{ $labels.base_url }} has less than 10% usable disk space remaining, an imminent risk of index corruption or write failures.
-                query: 'min by (base_url) (solr_metrics_core_fs_bytes{item="usableSpace"}) / max by (base_url) (solr_metrics_core_fs_bytes{item="totalSpace"}) <= 0.1'
-                severity: critical
-                for: 10m
               - name: Solr blocked or deadlocked JVM threads
                 description: Solr node {{ $labels.base_url }} has blocked or deadlocked JVM threads, indicating the JVM may be stuck and unable to serve requests.
                 query: 'max by (base_url) (solr_metrics_jvm_threads{item=~"blocked|deadlock"}) > 0'
                 severity: critical
                 for: 2m
+              - name: Solr query errors
+                description: Solr has increased query errors in collection {{ $labels.collection }} for replica {{ $labels.replica }} on {{ $labels.base_url }}.
+                query: 'increase(solr_metrics_core_errors_total{category="QUERY"}[1m]) > 1'
+                severity: warning
+                for: 5m
 
   - name: Message brokers
     services:
@@ -2366,6 +2681,9 @@ groups:
             slug: rabbitmq-exporter
             doc_url: https://github.com/rabbitmq/rabbitmq-prometheus
             rules:
+              #
+              # Availability
+              #
               - name: RabbitMQ node down
                 description: Less than 3 nodes running in RabbitMQ cluster
                 query: "sum(rabbitmq_build_info) < 3"
@@ -2373,6 +2691,49 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: RabbitMQ memory alarm active
+                description: Memory alarm is active on node {{ $labels.instance }} (vm_memory_high_watermark reached); publishers are blocked cluster-wide until memory is freed.
+                query: "rabbitmq_alarms_memory_used_watermark > 0"
+                severity: critical
+                for: 1m
+              - name: RabbitMQ memory high
+                description: A node use more than 90% of allocated RAM
+                query: "rabbitmq_process_resident_memory_bytes / rabbitmq_resident_memory_limit_bytes * 100 > 90 and rabbitmq_resident_memory_limit_bytes > 0"
+                severity: warning
+                for: 2m
+              - name: RabbitMQ disk space alarm active
+                description: Disk space alarm is active on node {{ $labels.instance }} (disk_free_limit reached); publishers are blocked cluster-wide until disk space is freed.
+                query: "rabbitmq_alarms_free_disk_space_watermark > 0"
+                severity: critical
+                for: 1m
+              - name: RabbitMQ predicted low disk watermark
+                description: Based on the trend of available disk space over the last 24h, node {{ $labels.instance }} is predicted to hit its disk space alarm threshold within 24 hours, which would block all publishers cluster-wide.
+                query: "predict_linear(rabbitmq_disk_space_available_bytes[24h], 24*3600) < rabbitmq_disk_space_available_limit_bytes"
+                severity: warning
+                for: 1h
+              - name: RabbitMQ file descriptors usage
+                description: A node use more than 90% of file descriptors
+                query: "rabbitmq_process_open_fds / rabbitmq_process_max_fds * 100 > 90 and rabbitmq_process_max_fds > 0"
+                severity: warning
+                for: 2m
+              - name: RabbitMQ too many connections
+                description: The total connections of a node is too high
+                query: "rabbitmq_connections > 1000"
+                severity: warning
+                for: 2m
+              - name: RabbitMQ high connection churn
+                description: "{{ $value | humanizePercentage }} of RabbitMQ connections are being opened or closed per second, indicating clients use short-lived connections instead of long-lived ones, which wastes CPU and file descriptors."
+                query: "(sum(rate(rabbitmq_connections_closed_total[5m])) + sum(rate(rabbitmq_connections_opened_total[5m]))) / sum(rabbitmq_connections) > 0.1 and sum(rabbitmq_connections) >= 100"
+                severity: warning
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: RabbitMQ node not distributed
                 description: Distribution link to peer {{ $labels.peer }} is not 'up' (state {{ $value }})
                 query: "erlang_vm_dist_node_state < 3"
@@ -2385,16 +2746,6 @@ groups:
                 query: "count(count(rabbitmq_build_info) by (rabbitmq_version)) > 1"
                 severity: warning
                 for: 1h
-              - name: RabbitMQ memory high
-                description: A node use more than 90% of allocated RAM
-                query: "rabbitmq_process_resident_memory_bytes / rabbitmq_resident_memory_limit_bytes * 100 > 90 and rabbitmq_resident_memory_limit_bytes > 0"
-                severity: warning
-                for: 2m
-              - name: RabbitMQ file descriptors usage
-                description: A node use more than 90% of file descriptors
-                query: "rabbitmq_process_open_fds / rabbitmq_process_max_fds * 100 > 90 and rabbitmq_process_max_fds > 0"
-                severity: warning
-                for: 2m
               - name: RabbitMQ too many ready messages
                 description: RabbitMQ too many ready messages on queue {{ $labels.queue }} ({{ $value }})
                 query: "sum(rabbitmq_queue_messages_ready) BY (queue) > 1000"
@@ -2405,11 +2756,6 @@ groups:
                 query: "sum(rabbitmq_queue_messages_unacked) BY (queue) > 1000"
                 severity: warning
                 for: 1m
-              - name: RabbitMQ too many connections
-                description: The total connections of a node is too high
-                query: "rabbitmq_connections > 1000"
-                severity: warning
-                for: 2m
               - name: RabbitMQ no queue consumer
                 description: A queue has less than 1 consumer
                 query: "rabbitmq_queue_consumers < 1"
@@ -2422,31 +2768,14 @@ groups:
                 for: 2m
                 comments: |
                   Threshold of 3 avoids noise from occasional misroutes. Adjust based on your expected traffic patterns.
-              - name: RabbitMQ memory alarm active
-                description: Memory alarm is active on node {{ $labels.instance }} (vm_memory_high_watermark reached); publishers are blocked cluster-wide until memory is freed.
-                query: "rabbitmq_alarms_memory_used_watermark > 0"
-                severity: critical
-                for: 1m
-              - name: RabbitMQ disk space alarm active
-                description: Disk space alarm is active on node {{ $labels.instance }} (disk_free_limit reached); publishers are blocked cluster-wide until disk space is freed.
-                query: "rabbitmq_alarms_free_disk_space_watermark > 0"
-                severity: critical
-                for: 1m
-              - name: RabbitMQ high connection churn
-                description: "{{ $value | humanizePercentage }} of RabbitMQ connections are being opened or closed per second, indicating clients use short-lived connections instead of long-lived ones, which wastes CPU and file descriptors."
-                query: "(sum(rate(rabbitmq_connections_closed_total[5m])) + sum(rate(rabbitmq_connections_opened_total[5m]))) / sum(rabbitmq_connections) > 0.1 and sum(rabbitmq_connections) >= 100"
-                severity: warning
-                for: 10m
-              - name: RabbitMQ predicted low disk watermark
-                description: Based on the trend of available disk space over the last 24h, node {{ $labels.instance }} is predicted to hit its disk space alarm threshold within 24 hours, which would block all publishers cluster-wide.
-                query: "predict_linear(rabbitmq_disk_space_available_bytes[24h], 24*3600) < rabbitmq_disk_space_available_limit_bytes"
-                severity: warning
-                for: 1h
 
           - name: kbudde/rabbitmq-exporter
             slug: kbudde-rabbitmq-exporter
             doc_url: https://github.com/kbudde/rabbitmq_exporter
             rules:
+              #
+              # Availability
+              #
               - name: RabbitMQ down
                 description: RabbitMQ node down
                 query: "rabbitmq_up == 0"
@@ -2465,6 +2794,10 @@ groups:
                 description: RabbitMQ cluster has a network partition ({{ $value }} partitions detected). Messages may be lost or duplicated.
                 query: "rabbitmq_partitions > 0"
                 severity: critical
+
+              #
+              # Resource saturation (USE)
+              #
               - name: RabbitMQ out of memory
                 description: Memory available for RabbitMQ is low (< 10%)
                 query: "rabbitmq_node_mem_used / rabbitmq_node_mem_limit * 100 > 90 and rabbitmq_node_mem_limit > 0"
@@ -2475,6 +2808,23 @@ groups:
                 query: "rabbitmq_connections > 1000"
                 severity: warning
                 for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: RabbitMQ no consumer
+                description: Queue has no consumer
+                query: "rabbitmq_queue_consumers == 0"
+                severity: critical
+                for: 5m
+                comments: |
+                  Allows a short service restart.
+              - name: RabbitMQ too many consumers
+                description: Queue should have only 1 consumer
+                query: 'rabbitmq_queue_consumers{queue="my-queue"} > 1'
+                severity: critical
+                comments: |
+                  Indicate the queue name in dedicated label.
               - name: RabbitMQ dead letter queue filling up
                 description: Dead letter queue is filling up (> 10 msgs)
                 query: 'rabbitmq_queue_messages{queue="my-dead-letter-queue"} > 10'
@@ -2496,19 +2846,6 @@ groups:
                 for: 2m
                 comments: |
                   Indicate the queue name in dedicated label.
-              - name: RabbitMQ no consumer
-                description: Queue has no consumer
-                query: "rabbitmq_queue_consumers == 0"
-                severity: critical
-                for: 5m
-                comments: |
-                  Allows a short service restart.
-              - name: RabbitMQ too many consumers
-                description: Queue should have only 1 consumer
-                query: 'rabbitmq_queue_consumers{queue="my-queue"} > 1'
-                severity: critical
-                comments: |
-                  Indicate the queue name in dedicated label.
               - name: RabbitMQ inactive exchange
                 description: Exchange receive less than 5 msgs per second
                 query: 'rate(rabbitmq_exchange_messages_published_in_total{exchange="my-exchange"}[1m]) < 5'
@@ -2528,6 +2865,9 @@ groups:
             slug: dabealu-zookeeper-exporter
             doc_url: https://github.com/dabealu/zookeeper-exporter
             rules:
+              #
+              # Availability
+              #
               - name: Zookeeper Down
                 description: "Zookeeper down on instance {{ $labels.instance }}"
                 query: "zk_up == 0"
@@ -2543,6 +2883,10 @@ groups:
                 description: "Zookeeper cluster has {{ $value }} nodes marked as leader (expected 1), indicating a split-brain"
                 query: "sum(zk_server_leader) > 1"
                 severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Zookeeper Not Ok
                 description: "Zookeeper instance {{ $labels.instance }} is not ok (ruok check failed)"
                 query: "zk_ruok == 0"
@@ -2556,6 +2900,9 @@ groups:
             slug: danielqsj-kafka-exporter
             doc_url: https://github.com/danielqsj/kafka_exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Kafka topics replicas
                 description: Kafka topic {{ $labels.topic }} has fewer than 3 in-sync replicas ({{ $value }}), data durability is at risk.
                 query: "min(kafka_topic_partition_in_sync_replica) by (topic) < 3"
@@ -2574,6 +2921,9 @@ groups:
             slug: linkedin-kafka-exporter
             doc_url: https://github.com/linkedin/Burrow
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Kafka topic offset decreased
                 description: Kafka topic offset has decreased
                 query: "delta(kafka_burrow_partition_current_offset[1m]) < 0"
@@ -2591,21 +2941,26 @@ groups:
             slug: embedded-exporter
             doc_url: https://pulsar.apache.org/docs/reference-metrics/
             rules:
-              - name: Pulsar subscription high number of backlog entries
-                description: "The number of subscription backlog entries is over 5k"
-                query: sum(pulsar_subscription_back_log) by (subscription) > 5000
+              #
+              # Resource saturation (USE)
+              #
+              - name: Pulsar high ledger disk usage
+                description: "Observing Ledger Disk Usage (> 75%)"
+                query: sum(bookie_ledger_dir__pulsar_data_bookkeeper_ledgers_usage) by (kubernetes_pod_name) > 75
                 for: 1h
-                severity: warning
+                severity: critical
+                comments: |
+                  This metric name is path-dependent and may differ based on your BookKeeper data directory configuration.
+                  Adjust the metric name to match your actual ledger directory path.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Pulsar subscription very high number of backlog entries
                 description: "The number of subscription backlog entries is over 100k"
                 query: sum(pulsar_subscription_back_log) by (subscription) > 100000
                 for: 1h
                 severity: critical
-              - name: Pulsar topic large backlog storage size
-                description: "The topic backlog storage size is over 5 GB"
-                query: sum(pulsar_storage_size) by (topic) > 5*1024*1024*1024
-                for: 1h
-                severity: warning
               - name: Pulsar topic very large backlog storage size
                 description: "The topic backlog storage size is over 20 GB"
                 query: sum(pulsar_storage_size) by (topic) > 20*1024*1024*1024
@@ -2619,22 +2974,6 @@ groups:
                 comments: |
                   pulsar_storage_write_latency_le_overflow is the overflow bucket of Pulsar's non-standard histogram.
                   It counts write operations exceeding all defined latency bounds (> 1000ms).
-              - name: Pulsar large message payload
-                description: "Pulsar topic {{ $labels.topic }} has {{ $value }} message entries exceeding the maximum size bucket (> 1MB)"
-                query: sum(pulsar_entry_size_le_overflow > 0) by (topic)
-                for: 1h
-                severity: warning
-                comments: |
-                  pulsar_entry_size_le_overflow is the overflow bucket of Pulsar's non-standard histogram.
-                  It counts message entries exceeding all defined size bounds.
-              - name: Pulsar high ledger disk usage
-                description: "Observing Ledger Disk Usage (> 75%)"
-                query: sum(bookie_ledger_dir__pulsar_data_bookkeeper_ledgers_usage) by (kubernetes_pod_name) > 75
-                for: 1h
-                severity: critical
-                comments: |
-                  This metric name is path-dependent and may differ based on your BookKeeper data directory configuration.
-                  Adjust the metric name to match your actual ledger directory path.
               - name: Pulsar read only bookies
                 description: "Observing Readonly Bookies"
                 query: count(bookie_SERVER_STATUS{} == 0) by (pod)
@@ -2650,6 +2989,24 @@ groups:
                 query: sum(rate(pulsar_sink_sink_exceptions_total[1m])) by (name) > 10
                 for: 1m
                 severity: critical
+              - name: Pulsar subscription high number of backlog entries
+                description: "The number of subscription backlog entries is over 5k"
+                query: sum(pulsar_subscription_back_log) by (subscription) > 5000
+                for: 1h
+                severity: warning
+              - name: Pulsar topic large backlog storage size
+                description: "The topic backlog storage size is over 5 GB"
+                query: sum(pulsar_storage_size) by (topic) > 5*1024*1024*1024
+                for: 1h
+                severity: warning
+              - name: Pulsar large message payload
+                description: "Pulsar topic {{ $labels.topic }} has {{ $value }} message entries exceeding the maximum size bucket (> 1MB)"
+                query: sum(pulsar_entry_size_le_overflow > 0) by (topic)
+                for: 1h
+                severity: warning
+                comments: |
+                  pulsar_entry_size_le_overflow is the overflow bucket of Pulsar's non-standard histogram.
+                  It counts message entries exceeding all defined size bounds.
 
       - name: Nats
         logo: /images/services/nats.svg
@@ -2658,21 +3015,9 @@ groups:
             slug: nats-exporter
             doc_url: https://github.com/nats-io/prometheus-nats-exporter
             rules:
-              - name: Nats high routes count
-                description: High number of NATS routes ({{ $value }}) for {{ $labels.instance }}
-                query: "gnatsd_varz_routes > 10"
-                severity: warning
-                for: 3m
-              - name: Nats high memory usage
-                description: NATS server memory usage is above 200MB for {{ $labels.instance }}
-                query: "gnatsd_varz_mem > 200 * 1024 * 1024"
-                severity: warning
-                for: 5m
-              - name: Nats slow consumers
-                description: There are slow consumers in NATS for {{ $labels.instance }}
-                query: "gnatsd_varz_slow_consumers > 0"
-                severity: critical
-                for: 3m
+              #
+              # Availability
+              #
               - name: Nats server down
                 description: NATS server has been down for more than 5 minutes
                 query: 'absent(up{job="nats"})'
@@ -2681,6 +3026,10 @@ groups:
                 comments: |
                   Replace job="nats" with the actual job name in your Prometheus configuration.
               # gnatsd_varz_cpu is a gauge, not a counter. Compare it directly, never wrap it in rate().
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Nats high CPU usage
                 description: NATS server is using more than 80% CPU for the last 5 minutes
                 query: "gnatsd_varz_cpu > 80"
@@ -2688,14 +3037,9 @@ groups:
                 for: 5m
                 comments: |
                   gnatsd_varz_cpu reports CPU usage on a 0-100 scale, not 0-1.
-              - name: Nats high number of connections
-                description: NATS server has more than 1000 active connections
-                query: "gnatsd_connz_num_connections > 1000"
-                severity: warning
-                for: 5m
-              - name: Nats high JetStream store usage
-                description: JetStream store usage is over 80%
-                query: "gnatsd_varz_jetstream_stats_storage / gnatsd_varz_jetstream_config_max_storage > 0.8 and gnatsd_varz_jetstream_config_max_storage > 0"
+              - name: Nats high memory usage
+                description: NATS server memory usage is above 200MB for {{ $labels.instance }}
+                query: "gnatsd_varz_mem > 200 * 1024 * 1024"
                 severity: warning
                 for: 5m
               - name: Nats high JetStream memory usage
@@ -2703,6 +3047,38 @@ groups:
                 query: "gnatsd_varz_jetstream_stats_memory / gnatsd_varz_jetstream_config_max_memory > 0.8 and gnatsd_varz_jetstream_config_max_memory > 0"
                 severity: warning
                 for: 5m
+              - name: Nats high JetStream store usage
+                description: JetStream store usage is over 80%
+                query: "gnatsd_varz_jetstream_stats_storage / gnatsd_varz_jetstream_config_max_storage > 0.8 and gnatsd_varz_jetstream_config_max_storage > 0"
+                severity: warning
+                for: 5m
+              - name: Nats high number of connections
+                description: NATS server has more than 1000 active connections
+                query: "gnatsd_connz_num_connections > 1000"
+                severity: warning
+                for: 5m
+              - name: Nats leaf node connection issue
+                description: No leaf node connections on {{ $labels.instance }}
+                query: "gnatsd_varz_leafnodes == 0"
+                severity: warning
+                for: 5m
+                comments: |
+                  Only enable this alert if your deployment requires leaf node connections.
+                  This will fire spuriously if leaf nodes are not configured.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Nats slow consumers
+                description: There are slow consumers in NATS for {{ $labels.instance }}
+                query: "gnatsd_varz_slow_consumers > 0"
+                severity: critical
+                for: 3m
+              - name: Nats high routes count
+                description: High number of NATS routes ({{ $value }}) for {{ $labels.instance }}
+                query: "gnatsd_varz_routes > 10"
+                severity: warning
+                for: 3m
               - name: Nats high number of subscriptions
                 description: NATS server has more than 1000 active subscriptions
                 query: "gnatsd_varz_subscriptions > 1000"
@@ -2723,14 +3099,6 @@ groups:
                 query: "sum(gnatsd_varz_jetstream_stats_accounts) > 100"
                 severity: warning
                 for: 5m
-              - name: Nats leaf node connection issue
-                description: No leaf node connections on {{ $labels.instance }}
-                query: "gnatsd_varz_leafnodes == 0"
-                severity: warning
-                for: 5m
-                comments: |
-                  Only enable this alert if your deployment requires leaf node connections.
-                  This will fire spuriously if leaf nodes are not configured.
 
   - name: Proxies, load balancers and service meshes
     services:
@@ -2741,6 +3109,9 @@ groups:
             slug: knyar-nginx-exporter
             doc_url: https://github.com/knyar/nginx-lua-prometheus
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Nginx high HTTP 4xx error rate
                 description: Too many HTTP requests with status 4xx (> 5%)
                 query: 'sum(rate(nginx_http_requests_total{status=~"^4.."}[1m])) / sum(rate(nginx_http_requests_total[1m])) * 100 > 5 and sum(rate(nginx_http_requests_total[1m])) > 0'
@@ -2769,24 +3140,31 @@ groups:
             slug: lusitaniae-apache-exporter
             doc_url: https://github.com/Lusitaniae/apache_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Apache down
                 description: Apache down
                 query: "apache_up == 0"
                 severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Apache workers load
                 description: Apache workers in busy state approach the max workers count 80% workers busy on {{ $labels.instance }}
                 query: '(sum by (instance) (apache_workers{state="busy"}) / sum by (instance) (apache_scoreboard) ) * 100 > 80 and sum by (instance) (apache_scoreboard) > 0'
+                severity: warning
+                for: 2m
+              - name: Apache response time too high
+                description: Apache average response time on {{ $labels.instance }} is {{ $value }}ms over the last 5 minutes.
+                query: "increase(apache_duration_ms_total[5m]) / increase(apache_accesses_total[5m]) > 5000 and increase(apache_accesses_total[5m]) > 0"
                 severity: warning
                 for: 2m
               - name: Apache restart
                 description: Apache has just been restarted.
                 query: "apache_uptime_seconds_total / 60 < 1"
                 severity: info
-              - name: Apache response time too high
-                description: Apache average response time on {{ $labels.instance }} is {{ $value }}ms over the last 5 minutes.
-                query: "increase(apache_duration_ms_total[5m]) / increase(apache_accesses_total[5m]) > 5000 and increase(apache_accesses_total[5m]) > 0"
-                severity: warning
-                for: 2m
 
       - name: HaProxy
         logo: /images/services/haproxy.svg
@@ -2795,6 +3173,30 @@ groups:
             slug: embedded-exporter-v2
             doc_url: https://github.com/haproxy/haproxy/tree/master/contrib/prometheus-exporter
             rules:
+              #
+              # Availability
+              #
+              - name: HAProxy HTTP slowing down
+                description: HAProxy backend max total time is above 1s on {{ $labels.proxy }} - {{ $value | printf "%.2f"}}s
+                query: avg by (instance, proxy) (haproxy_backend_max_total_time_seconds) > 1
+                severity: warning
+                for: 1m
+              - name: HAProxy dropping logs
+                description: HAProxy {{ $labels.instance }} is dropping log messages, which usually indicates the syslog/logging backend cannot keep up or is unreachable.
+                query: "rate(haproxy_process_dropped_logs_total[5m]) != 0"
+                severity: warning
+              - name: HAProxy backend healthcheck flapping
+                description: Backend {{ $labels.proxy }} on {{ $labels.instance }} has servers repeatedly transitioning between UP and DOWN health-check states, which points to unstable health checks or a flaky network path rather than a hard failure.
+                query: "rate(haproxy_backend_check_up_down_total[5m]) != 0"
+                severity: warning
+              - name: HAProxy server healthcheck flapping
+                description: Server {{ $labels.server }} on {{ $labels.instance }} is repeatedly transitioning between UP and DOWN health-check states, which may indicate an unstable backend node or overly sensitive health-check thresholds.
+                query: "rate(haproxy_server_check_up_down_total[5m]) != 0"
+                severity: warning
+
+              #
+              # Performance and errors (RED)
+              #
               - name: HAProxy high HTTP 4xx error rate backend
                 description: Too many HTTP requests with status 4xx (> 5%) on backend {{ $labels.proxy }}
                 query: ((sum by (proxy) (rate(haproxy_server_http_responses_total{code="4xx"}[1m])) / sum by (proxy) (rate(haproxy_server_http_responses_total[1m]))) * 100) > 5 and sum by (proxy) (rate(haproxy_server_http_responses_total[1m])) > 0
@@ -2841,49 +3243,60 @@ groups:
                 query: sum by (proxy) (haproxy_backend_current_queue) > 0
                 severity: warning
                 for: 2m
-              - name: HAProxy HTTP slowing down
-                description: HAProxy backend max total time is above 1s on {{ $labels.proxy }} - {{ $value | printf "%.2f"}}s
-                query: avg by (instance, proxy) (haproxy_backend_max_total_time_seconds) > 1
-                severity: warning
-                for: 1m
               - name: HAProxy retry high
                 description: High rate of retry on {{ $labels.proxy }} - {{ $value | printf "%.2f"}}
                 query: sum by (proxy) (rate(haproxy_backend_retry_warnings_total[1m])) > 10
-                severity: warning
-                for: 2m
-              - name: HAproxy has no alive backends
-                description: HAProxy has no alive active or backup backends for {{ $labels.proxy }}
-                query: haproxy_backend_active_servers + haproxy_backend_backup_servers == 0
-                severity: critical
-              - name: HAProxy frontend security blocked requests
-                description: HAProxy is blocking requests for security reason
-                query: sum by (proxy) (rate(haproxy_frontend_denied_connections_total[2m])) > 10
                 severity: warning
                 for: 2m
               - name: HAProxy server healthcheck failure
                 description: Some server healthcheck are failing on {{ $labels.server }} ({{ $value }} in the last 1m)
                 query: increase(haproxy_server_check_failures_total[1m]) > 2
                 severity: warning
-              - name: HAProxy dropping logs
-                description: HAProxy {{ $labels.instance }} is dropping log messages, which usually indicates the syslog/logging backend cannot keep up or is unreachable.
-                query: "rate(haproxy_process_dropped_logs_total[5m]) != 0"
+
+              #
+              # Capacity and trend
+              #
+              - name: HAproxy has no alive backends
+                description: HAProxy has no alive active or backup backends for {{ $labels.proxy }}
+                query: haproxy_backend_active_servers + haproxy_backend_backup_servers == 0
+                severity: critical
+
+              #
+              # Info, security, and config
+              #
+              - name: HAProxy frontend security blocked requests
+                description: HAProxy is blocking requests for security reason
+                query: sum by (proxy) (rate(haproxy_frontend_denied_connections_total[2m])) > 10
                 severity: warning
-              - name: HAProxy backend healthcheck flapping
-                description: Backend {{ $labels.proxy }} on {{ $labels.instance }} has servers repeatedly transitioning between UP and DOWN health-check states, which points to unstable health checks or a flaky network path rather than a hard failure.
-                query: "rate(haproxy_backend_check_up_down_total[5m]) != 0"
-                severity: warning
-              - name: HAProxy server healthcheck flapping
-                description: Server {{ $labels.server }} on {{ $labels.instance }} is repeatedly transitioning between UP and DOWN health-check states, which may indicate an unstable backend node or overly sensitive health-check thresholds.
-                query: "rate(haproxy_server_check_up_down_total[5m]) != 0"
-                severity: warning
+                for: 2m
           - name: prometheus/haproxy_exporter (HAProxy < v2)
             slug: haproxy-exporter-v1
             doc_url: https://github.com/prometheus/haproxy_exporter
             rules:
+              #
+              # Availability
+              #
               - name: HAProxy down
                 description: HAProxy down
                 query: "haproxy_up == 0"
                 severity: critical
+              - name: HAProxy backend down
+                description: HAProxy backend is down
+                query: "haproxy_backend_up == 0"
+                severity: critical
+              - name: HAProxy server down
+                description: HAProxy server is down
+                query: "haproxy_server_up == 0"
+                severity: critical
+              - name: HAProxy HTTP slowing down (v1)
+                description: Average request time is increasing
+                query: "avg by (backend) (haproxy_backend_http_total_time_average_seconds) > 1"
+                severity: warning
+                for: 1m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: HAProxy high HTTP 4xx error rate backend (v1)
                 description: Too many HTTP requests with status 4xx (> 5%) on backend {{ $labels.backend }}
                 query: 'sum by (backend) (rate(haproxy_server_http_responses_total{code="4xx"}[1m])) / sum by (backend) (rate(haproxy_server_http_responses_total[1m])) * 100 > 5 and sum by (backend) (rate(haproxy_server_http_responses_total[1m])) > 0'
@@ -2928,33 +3341,24 @@ groups:
                 query: "sum by (backend) (haproxy_backend_current_queue) > 0"
                 severity: warning
                 for: 2m
-              - name: HAProxy HTTP slowing down (v1)
-                description: Average request time is increasing
-                query: "avg by (backend) (haproxy_backend_http_total_time_average_seconds) > 1"
-                severity: warning
-                for: 1m
               - name: HAProxy retry high (v1)
                 description: High rate of retry on {{ $labels.backend }} backend
                 query: "sum by (backend) (rate(haproxy_backend_retry_warnings_total[1m])) > 10"
-                severity: warning
-                for: 2m
-              - name: HAProxy backend down
-                description: HAProxy backend is down
-                query: "haproxy_backend_up == 0"
-                severity: critical
-              - name: HAProxy server down
-                description: HAProxy server is down
-                query: "haproxy_server_up == 0"
-                severity: critical
-              - name: HAProxy frontend security blocked requests (v1)
-                description: HAProxy is blocking requests for security reason
-                query: "sum by (frontend) (rate(haproxy_frontend_requests_denied_total[2m])) > 10"
                 severity: warning
                 for: 2m
               - name: HAProxy server healthcheck failure (v1)
                 description: Some server healthcheck are failing on {{ $labels.server }} ({{ $value }} in the last 1m)
                 query: "increase(haproxy_server_check_failures_total[1m]) > 2"
                 severity: warning
+
+              #
+              # Info, security, and config
+              #
+              - name: HAProxy frontend security blocked requests (v1)
+                description: HAProxy is blocking requests for security reason
+                query: "sum by (frontend) (rate(haproxy_frontend_requests_denied_total[2m])) > 10"
+                severity: warning
+                for: 2m
 
       - name: Traefik
         logo: /images/services/traefik.svg
@@ -2963,10 +3367,17 @@ groups:
             slug: embedded-exporter-v2
             doc_url: https://docs.traefik.io/observability/metrics/prometheus/
             rules:
+              #
+              # Availability
+              #
               - name: Traefik service down
                 description: All Traefik services are down
                 query: "count(traefik_service_server_up) by (service) == 0"
                 severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Traefik high HTTP 4xx error rate service
                 description: Traefik service 4xx error rate is above 5%
                 query: 'sum(rate(traefik_service_requests_total{code=~"4.*"}[3m])) by (service) / sum(rate(traefik_service_requests_total[3m])) by (service) * 100 > 5 and sum(rate(traefik_service_requests_total[3m])) by (service) > 0'
@@ -2977,6 +3388,14 @@ groups:
                 query: 'sum(rate(traefik_service_requests_total{code=~"5.*"}[3m])) by (service) / sum(rate(traefik_service_requests_total[3m])) by (service) * 100 > 5 and sum(rate(traefik_service_requests_total[3m])) by (service) > 0'
                 severity: critical
                 for: 1m
+
+              #
+              # Info, security, and config
+              #
+              - name: Traefik certificate expiring imminently
+                description: TLS certificate for {{ $labels.sans }} served by Traefik instance {{ $labels.instance }} expires in less than 7 days and must be renewed urgently.
+                query: "min by (instance, sans) (last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400 < 7"
+                severity: critical
               - name: Traefik config reload failure
                 description: Traefik dynamic configuration reload is failing on {{ $labels.job }}, so recent routing and provider configuration changes may not be applied.
                 query: "sum(rate(traefik_config_reloads_failure_total[3m])) by (job) > 0"
@@ -2986,18 +3405,21 @@ groups:
                 description: TLS certificate for {{ $labels.sans }} served by Traefik instance {{ $labels.instance }} expires in less than 14 days.
                 query: "min by (instance, sans) (last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400 < 14"
                 severity: warning
-              - name: Traefik certificate expiring imminently
-                description: TLS certificate for {{ $labels.sans }} served by Traefik instance {{ $labels.instance }} expires in less than 7 days and must be renewed urgently.
-                query: "min by (instance, sans) (last_over_time(traefik_tls_certs_not_after[5m]) - time()) / 86400 < 7"
-                severity: critical
           - name: Embedded exporter v1
             slug: embedded-exporter-v1
             doc_url: https://docs.traefik.io/observability/metrics/prometheus/
             rules:
+              #
+              # Availability
+              #
               - name: Traefik backend down
                 description: All Traefik backends are down
                 query: "count(traefik_backend_server_up) by (backend) == 0"
                 severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Traefik high HTTP 4xx error rate backend
                 description: Traefik backend 4xx error rate is above 5%
                 query: 'sum(rate(traefik_backend_requests_total{code=~"4.*"}[3m])) by (backend) / sum(rate(traefik_backend_requests_total[3m])) by (backend) * 100 > 5 and sum(rate(traefik_backend_requests_total[3m])) by (backend) > 0'
@@ -3016,11 +3438,17 @@ groups:
             slug: embedded-exporter
             doc_url: https://caddyserver.com/docs/metrics
             rules:
+              #
+              # Availability
+              #
               - name: Caddy Reverse Proxy Down
                 description: "Caddy reverse proxy upstream {{ $labels.upstream }} is unhealthy"
                 query: "caddy_reverse_proxy_upstreams_healthy == 0"
                 severity: critical
 
+              #
+              # Performance and errors (RED)
+              #
               - name: Caddy high HTTP 4xx error rate service
                 description: "Caddy service 4xx error rate is above 5%"
                 query: 'sum(rate(caddy_http_request_duration_seconds_count{code=~"4.."}[3m])) by (instance) / sum(rate(caddy_http_request_duration_seconds_count[3m])) by (instance) * 100 > 5 and sum(rate(caddy_http_request_duration_seconds_count[3m])) by (instance) > 0'
@@ -3039,35 +3467,63 @@ groups:
             slug: embedded-exporter
             doc_url: https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/statistics
             rules:
+              #
+              # Availability
+              #
               - name: Envoy server not live
                 description: "Envoy server is not live (draining or shutting down) on {{ $labels.instance }}"
                 query: "envoy_server_live != 1"
                 severity: critical
                 for: 1m
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Envoy high memory usage
                 description: "Envoy memory allocated is above 90% of heap size on {{ $labels.instance }}"
                 query: "envoy_server_memory_allocated / envoy_server_memory_heap_size * 100 > 90 and envoy_server_memory_heap_size > 0"
                 severity: warning
                 for: 5m
+              - name: Envoy global downstream connections overflowing
+                description: "Downstream connections are being rejected due to global connection limit on {{ $labels.instance }} ({{ $value }} in the last 5m)"
+                query: "increase(envoy_listener_downstream_global_cx_overflow[5m]) > 5"
+                severity: critical
+              - name: Envoy downstream connections overflowing
+                description: "Downstream connections are being rejected due to listener overflow on {{ $labels.instance }} ({{ $value }} in the last 5m)"
+                query: "increase(envoy_listener_downstream_cx_overflow[5m]) > 5"
+                severity: warning
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Envoy high downstream HTTP 5xx error rate
                 description: "More than 5% of downstream HTTP responses are 5xx on {{ $labels.instance }} ({{ $value | printf \"%.1f\" }}%)"
                 query: 'sum by (instance) (rate(envoy_http_downstream_rq_xx{envoy_response_code_class="5"}[5m])) / sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) * 100 > 5 and sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) > 0'
                 severity: critical
                 for: 1m
-              - name: Envoy high downstream HTTP 4xx error rate
-                description: "More than 10% of downstream HTTP responses are 4xx on {{ $labels.instance }} ({{ $value | printf \"%.1f\" }}%)"
-                query: 'sum by (instance) (rate(envoy_http_downstream_rq_xx{envoy_response_code_class="4"}[5m])) / sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) * 100 > 10 and sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) > 0'
-                severity: warning
-                for: 5m
-              - name: Envoy downstream connections overflowing
-                description: "Downstream connections are being rejected due to listener overflow on {{ $labels.instance }} ({{ $value }} in the last 5m)"
-                query: "increase(envoy_listener_downstream_cx_overflow[5m]) > 5"
-                severity: warning
               - name: Envoy cluster membership empty
                 description: "Envoy cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }} has no healthy members"
                 query: "envoy_cluster_membership_healthy == 0"
                 severity: critical
                 for: 1m
+              - name: Envoy high cluster upstream 5xx error rate
+                description: "More than 5% of upstream requests return 5xx in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
+                query: 'rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]) / rate(envoy_cluster_upstream_rq_completed[5m]) * 100 > 5 and rate(envoy_cluster_upstream_rq_completed[5m]) > 0'
+                severity: critical
+                for: 1m
+              - name: Envoy cluster circuit breaker tripped
+                description: "Circuit breaker is open for cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
+                query: "envoy_cluster_circuit_breakers_default_cx_open == 1 or envoy_cluster_circuit_breakers_default_rq_open == 1 or envoy_cluster_circuit_breakers_default_cx_pool_open == 1"
+                severity: critical
+              - name: Envoy no healthy upstream
+                description: "Upstream connection attempts failed because no healthy upstream was available in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }} ({{ $value }} in the last 5m)"
+                query: "increase(envoy_cluster_upstream_cx_none_healthy[5m]) > 3"
+                severity: critical
+              - name: Envoy high downstream HTTP 4xx error rate
+                description: "More than 10% of downstream HTTP responses are 4xx on {{ $labels.instance }} ({{ $value | printf \"%.1f\" }}%)"
+                query: 'sum by (instance) (rate(envoy_http_downstream_rq_xx{envoy_response_code_class="4"}[5m])) / sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) * 100 > 10 and sum by (instance) (rate(envoy_http_downstream_rq_completed[5m])) > 0'
+                severity: warning
+                for: 5m
               - name: Envoy cluster membership degraded
                 description: "Only {{ $value | printf \"%.1f\" }}% of members in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }} are healthy (threshold: 75%)"
                 query: "envoy_cluster_membership_healthy / envoy_cluster_membership_total * 100 < 75 and envoy_cluster_membership_total > 0"
@@ -3083,45 +3539,11 @@ groups:
                 query: "rate(envoy_cluster_upstream_rq_timeout[5m]) / rate(envoy_cluster_upstream_rq_completed[5m]) * 100 > 5 and rate(envoy_cluster_upstream_rq_completed[5m]) > 0"
                 severity: warning
                 for: 5m
-              - name: Envoy high cluster upstream 5xx error rate
-                description: "More than 5% of upstream requests return 5xx in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
-                query: 'rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="5"}[5m]) / rate(envoy_cluster_upstream_rq_completed[5m]) * 100 > 5 and rate(envoy_cluster_upstream_rq_completed[5m]) > 0'
-                severity: critical
-                for: 1m
               - name: Envoy cluster health check failures
                 description: "Health checks are consistently failing in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }} ({{ $value }} in the last 5m)"
                 query: "increase(envoy_cluster_health_check_failure[5m]) > 5"
                 severity: warning
                 for: 5m
-              - name: Envoy cluster outlier detection ejections active
-                description: "There are active outlier detection ejections in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
-                query: "envoy_cluster_outlier_detection_ejections_active > 0"
-                severity: info
-                for: 5m
-              - name: Envoy listener SSL connection errors
-                description: "Envoy listener is experiencing SSL/TLS connection errors on {{ $labels.instance }} ({{ $value }} in the last 5m)"
-                query: "increase(envoy_listener_ssl_connection_error[5m]) > 5"
-                severity: warning
-              - name: Envoy global downstream connections overflowing
-                description: "Downstream connections are being rejected due to global connection limit on {{ $labels.instance }} ({{ $value }} in the last 5m)"
-                query: "increase(envoy_listener_downstream_global_cx_overflow[5m]) > 5"
-                severity: critical
-              - name: Envoy SSL certificate expiring soon
-                description: "SSL certificate loaded by Envoy on {{ $labels.instance }} expires in less than 7 days"
-                query: "envoy_server_days_until_first_cert_expiring < 7"
-                severity: warning
-              - name: Envoy SSL certificate expired
-                description: "SSL certificate loaded by Envoy on {{ $labels.instance }} has expired"
-                query: "envoy_server_days_until_first_cert_expiring < 0"
-                severity: critical
-              - name: Envoy cluster circuit breaker tripped
-                description: "Circuit breaker is open for cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
-                query: "envoy_cluster_circuit_breakers_default_cx_open == 1 or envoy_cluster_circuit_breakers_default_rq_open == 1 or envoy_cluster_circuit_breakers_default_cx_pool_open == 1"
-                severity: critical
-              - name: Envoy no healthy upstream
-                description: "Upstream connection attempts failed because no healthy upstream was available in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }} ({{ $value }} in the last 5m)"
-                query: "increase(envoy_cluster_upstream_cx_none_healthy[5m]) > 3"
-                severity: critical
               - name: Envoy high downstream request timeout rate
                 description: "Downstream requests are timing out on {{ $labels.instance }} ({{ $value }} in the last 5m)"
                 query: "increase(envoy_http_downstream_rq_timeout[5m]) > 5"
@@ -3132,6 +3554,27 @@ groups:
                 query: 'rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class="4"}[5m]) / rate(envoy_cluster_upstream_rq_completed[5m]) * 100 > 5 and rate(envoy_cluster_upstream_rq_completed[5m]) > 0'
                 severity: warning
                 for: 5m
+              - name: Envoy cluster outlier detection ejections active
+                description: "There are active outlier detection ejections in cluster {{ $labels.envoy_cluster_name }} on {{ $labels.instance }}"
+                query: "envoy_cluster_outlier_detection_ejections_active > 0"
+                severity: info
+                for: 5m
+
+              #
+              # Info, security, and config
+              #
+              - name: Envoy SSL certificate expired
+                description: "SSL certificate loaded by Envoy on {{ $labels.instance }} has expired"
+                query: "envoy_server_days_until_first_cert_expiring < 0"
+                severity: critical
+              - name: Envoy listener SSL connection errors
+                description: "Envoy listener is experiencing SSL/TLS connection errors on {{ $labels.instance }} ({{ $value }} in the last 5m)"
+                query: "increase(envoy_listener_ssl_connection_error[5m]) > 5"
+                severity: warning
+              - name: Envoy SSL certificate expiring soon
+                description: "SSL certificate loaded by Envoy on {{ $labels.instance }} expires in less than 7 days"
+                query: "envoy_server_days_until_first_cert_expiring < 7"
+                severity: warning
 
       - name: Linkerd
         logo: /images/services/linkerd.svg
@@ -3140,6 +3583,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://linkerd.io/2/tasks/exporting-metrics/
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Linkerd high error rate
                 description: "Linkerd error rate for {{ $labels.deployment }}{{ $labels.statefulset }}{{ $labels.daemonset }} is over 10%"
                 query: 'sum(rate(response_total{classification="failure"}[1m])) by (deployment, statefulset, daemonset) / sum(rate(response_total[1m])) by (deployment, statefulset, daemonset) * 100 > 10 and sum(rate(response_total[1m])) by (deployment, statefulset, daemonset) > 0'
@@ -3153,6 +3599,25 @@ groups:
             slug: embedded-exporter
             doc_url: https://istio.io/latest/docs/tasks/observability/metrics/querying-metrics/
             rules:
+              #
+              # Availability
+              #
+              - name: Istio control plane component down
+                description: Istio control plane component {{ $labels.component }} has stopped reporting for over 5 minutes, disrupting service discovery, configuration propagation, and traffic management across the mesh.
+                query: 'absent(istio_build{component="pilot"})'
+                severity: critical
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Istio Pilot Duplicate Entry
+                description: Istio Pilot has detected {{ $value }} duplicate Envoy cluster(s), indicating misconfigured DestinationRules or ServiceEntries.
+                query: "sum(pilot_duplicate_envoy_clusters{}) > 0"
+                severity: critical
+              # istio_build is an info-style gauge whose value is always 1, so it vanishes rather than
+              # dropping to 0 when istiod stops. Only absent() detects the outage; istio_build < 1 or
+              # == 0 can never fire.
               - name: Istio Kubernetes gateway availability drop
                 description: Istio ingress gateway has only {{ $value }} available pod(s). Inbound traffic will likely be affected.
                 query: 'min(kube_deployment_status_replicas_available{deployment="istio-ingressgateway", namespace="istio-system"}) without (instance, pod) < 2'
@@ -3204,18 +3669,6 @@ groups:
                 query: "histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket[1m])) by (destination_canonical_service, destination_workload_namespace, le)) > 1000"
                 severity: warning
                 for: 1m
-              - name: Istio Pilot Duplicate Entry
-                description: Istio Pilot has detected {{ $value }} duplicate Envoy cluster(s), indicating misconfigured DestinationRules or ServiceEntries.
-                query: "sum(pilot_duplicate_envoy_clusters{}) > 0"
-                severity: critical
-              # istio_build is an info-style gauge whose value is always 1, so it vanishes rather than
-              # dropping to 0 when istiod stops. Only absent() detects the outage; istio_build < 1 or
-              # == 0 can never fire.
-              - name: Istio control plane component down
-                description: Istio control plane component {{ $labels.component }} has stopped reporting for over 5 minutes, disrupting service discovery, configuration propagation, and traffic management across the mesh.
-                query: 'absent(istio_build{component="pilot"})'
-                severity: critical
-                for: 5m
 
   - name: Runtimes
     services:
@@ -3226,6 +3679,9 @@ groups:
             slug: bakins-fpm-exporter
             doc_url: https://github.com/bakins/php-fpm-exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: PHP-FPM max-children reached
                 description: PHP-FPM reached max children on {{ $labels.instance }} ({{ $value }} times in the last 5m)
                 query: "sum(increase(phpfpm_max_children_reached_total[5m])) by (instance) > 3"
@@ -3256,6 +3712,14 @@ groups:
             slug: jvm-exporter
             doc_url: https://github.com/prometheus/client_java
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: JVM compilation time spike
+                description: Excessive JIT compilation time consuming CPU
+                query: 'rate(jvm_compilation_time_seconds_total[5m]) > 0.1'
+                severity: warning
+                for: 5m
               - name: JVM memory filling up
                 description: JVM memory is filling up (> 80%)
                 query: '(sum by (instance)(jvm_memory_used_bytes{area="heap"}) / sum by (instance)(jvm_memory_max_bytes{area="heap"})) * 100 > 80 and sum by (instance)(jvm_memory_max_bytes{area="heap"}) > 0'
@@ -3269,16 +3733,36 @@ groups:
                 comments: |
                   Many JVM configurations leave metaspace unbounded, in which case jvm_memory_max_bytes{area="nonheap"} is -1 and this alert will not fire.
                   The query filters out max_bytes <= 0 to avoid false negatives.
-              - name: JVM GC time too high
-                description: JVM is spending too much time in garbage collection (> 5% of wall clock time)
-                query: 'sum by (instance)(rate(jvm_gc_collection_seconds_sum[5m])) > 0.05'
+              - name: JVM old gen GC frequency
+                description: Frequent old/major GC cycles, indicating memory pressure
+                query: 'rate(jvm_gc_collection_seconds_count{gc=~".*old.*|.*major.*"}[5m]) > 0.3'
                 severity: warning
                 for: 5m
+                comments: |
+                  This regex matches CMS, G1, and Parallel collector names. It will not match ZGC or Shenandoah cycle names.
+                  Adjust the gc label filter if you use a different collector.
+              - name: JVM file descriptors exhaustion
+                description: JVM process is running out of file descriptors (> 90% used)
+                query: '(process_open_fds / process_max_fds) * 100 > 90 and process_max_fds > 0'
+                severity: warning
+                for: 5m
+                comments: |
+                  process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not JVM-specific.
+                  This alert will also fire for Go, Python, or any process exposing these metrics.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: JVM threads deadlocked
                 description: JVM has deadlocked threads
                 query: 'jvm_threads_deadlocked > 0'
                 severity: critical
                 for: 1m
+              - name: JVM GC time too high
+                description: JVM is spending too much time in garbage collection (> 5% of wall clock time)
+                query: 'sum by (instance)(rate(jvm_gc_collection_seconds_sum[5m])) > 0.05'
+                severity: warning
+                for: 5m
               - name: JVM thread count high
                 description: JVM thread count is high (> 300), potential thread leak
                 query: 'jvm_threads_current > 300'
@@ -3289,14 +3773,6 @@ groups:
                 query: 'jvm_threads_state{state="BLOCKED"} > 50'
                 severity: warning
                 for: 5m
-              - name: JVM old gen GC frequency
-                description: Frequent old/major GC cycles, indicating memory pressure
-                query: 'rate(jvm_gc_collection_seconds_count{gc=~".*old.*|.*major.*"}[5m]) > 0.3'
-                severity: warning
-                for: 5m
-                comments: |
-                  This regex matches CMS, G1, and Parallel collector names. It will not match ZGC or Shenandoah cycle names.
-                  Adjust the gc label filter if you use a different collector.
               - name: JVM direct buffer pool filling up
                 description: JVM direct buffer pool is filling up (> 90%)
                 query: '(jvm_buffer_pool_used_bytes / jvm_buffer_pool_capacity_bytes) * 100 > 90 and jvm_buffer_pool_capacity_bytes > 0'
@@ -3307,22 +3783,9 @@ groups:
                 query: 'jvm_memory_objects_pending_finalization > 1000'
                 severity: warning
                 for: 5m
-              - name: JVM file descriptors exhaustion
-                description: JVM process is running out of file descriptors (> 90% used)
-                query: '(process_open_fds / process_max_fds) * 100 > 90 and process_max_fds > 0'
-                severity: warning
-                for: 5m
-                comments: |
-                  process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not JVM-specific.
-                  This alert will also fire for Go, Python, or any process exposing these metrics.
               - name: JVM class loading anomaly
                 description: Rapid class loading detected, potential classloader leak
                 query: 'rate(jvm_classes_loaded_total[5m]) > 100'
-                severity: warning
-                for: 5m
-              - name: JVM compilation time spike
-                description: Excessive JIT compilation time consuming CPU
-                query: 'rate(jvm_compilation_time_seconds_total[5m]) > 0.1'
                 severity: warning
                 for: 5m
 
@@ -3333,43 +3796,9 @@ groups:
             slug: golang-exporter
             doc_url: https://github.com/prometheus/client_golang
             rules:
-              - name: Go goroutine count high
-                description: Go application has too many goroutines (> 1000), potential goroutine leak
-                query: 'go_goroutines > 1000'
-                severity: warning
-                for: 5m
-                comments: |
-                  Threshold is a rough default. High-concurrency servers may legitimately run thousands of goroutines. Adjust to match your baseline.
-              - name: Go GC duration high
-                description: Go GC pause duration is too high (max > 1s)
-                query: 'go_gc_duration_seconds{quantile="1"} > 1'
-                severity: warning
-                for: 5m
-                comments: |
-                  quantile="1" is the maximum observed GC pause in the current summary window, not p99.
-                  A single outlier pause can push this above 1s. The for: 5m ensures the max stays elevated.
-              - name: Go memory usage high
-                description: Go heap allocation is using most of the runtime's reserved memory (> 90%), indicating the process may need more memory or has a leak
-                query: '(go_memstats_heap_alloc_bytes / go_memstats_sys_bytes) * 100 > 90'
-                severity: warning
-                for: 5m
-                comments: |
-                  go_memstats_sys_bytes is the total memory obtained from the OS by the Go runtime, not total host memory.
-                  This ratio measures Go-internal memory utilization, not system-level memory pressure.
-              - name: Go thread count high
-                description: Go OS thread count is high (> 500), potential blocking syscall or CGo leak
-                query: 'go_threads > 500'
-                severity: warning
-                for: 5m
-                comments: |
-                  Threshold is workload-dependent. Applications with heavy CGo or blocking I/O may legitimately use more OS threads. Adjust to match your baseline.
-              - name: Go heap objects count high
-                description: Go heap has too many live objects (> 10M), high GC pressure
-                query: 'go_memstats_heap_objects > 10000000'
-                severity: warning
-                for: 5m
-                comments: |
-                  Threshold is a rough default. Adjust based on your application's normal object count.
+              #
+              # Resource saturation (USE)
+              #
               - name: Go GC CPU fraction high
                 description: Go GC is consuming too much CPU (> 5%)
                 query: 'rate(go_gc_duration_seconds_sum[5m]) > 0.05'
@@ -3378,14 +3807,21 @@ groups:
                 comments: |
                   rate(go_gc_duration_seconds_sum) approximates the fraction of wall-clock time spent in GC.
                   This replaces go_memstats_gc_cpu_fraction which was removed in client_golang v1.12+.
-              - name: Go goroutine spike
-                description: Go goroutine count is growing rapidly ({{ $value | printf "%.0f" }} goroutines/s)
-                query: 'deriv(go_goroutines[5m]) > 10'
+              - name: Go memory usage high
+                description: Go heap allocation is using most of the runtime's reserved memory (> 90%), indicating the process may need more memory or has a leak
+                query: '(go_memstats_heap_alloc_bytes / go_memstats_sys_bytes) * 100 > 90'
                 severity: warning
                 for: 5m
                 comments: |
-                  A threshold of 100/s only catches catastrophic leaks (30k goroutines in 5m). 10/s catches gradual leaks (~3k in 5m).
-                  Adjust based on your application's expected concurrency patterns.
+                  go_memstats_sys_bytes is the total memory obtained from the OS by the Go runtime, not total host memory.
+                  This ratio measures Go-internal memory utilization, not system-level memory pressure.
+              - name: Go heap objects count high
+                description: Go heap has too many live objects (> 10M), high GC pressure
+                query: 'go_memstats_heap_objects > 10000000'
+                severity: warning
+                for: 5m
+                comments: |
+                  Threshold is a rough default. Adjust based on your application's normal object count.
               - name: Go heap in-use growing
                 description: Go heap in-use memory is growing steadily, potential memory leak or under-sized heap
                 query: 'deriv(go_memstats_heap_inuse_bytes[10m]) > 1e7'
@@ -3404,6 +3840,40 @@ groups:
                 severity: warning
                 for: 5m
 
+              #
+              # Performance and errors (RED)
+              #
+              - name: Go goroutine count high
+                description: Go application has too many goroutines (> 1000), potential goroutine leak
+                query: 'go_goroutines > 1000'
+                severity: warning
+                for: 5m
+                comments: |
+                  Threshold is a rough default. High-concurrency servers may legitimately run thousands of goroutines. Adjust to match your baseline.
+              - name: Go GC duration high
+                description: Go GC pause duration is too high (max > 1s)
+                query: 'go_gc_duration_seconds{quantile="1"} > 1'
+                severity: warning
+                for: 5m
+                comments: |
+                  quantile="1" is the maximum observed GC pause in the current summary window, not p99.
+                  A single outlier pause can push this above 1s. The for: 5m ensures the max stays elevated.
+              - name: Go thread count high
+                description: Go OS thread count is high (> 500), potential blocking syscall or CGo leak
+                query: 'go_threads > 500'
+                severity: warning
+                for: 5m
+                comments: |
+                  Threshold is workload-dependent. Applications with heavy CGo or blocking I/O may legitimately use more OS threads. Adjust to match your baseline.
+              - name: Go goroutine spike
+                description: Go goroutine count is growing rapidly ({{ $value | printf "%.0f" }} goroutines/s)
+                query: 'deriv(go_goroutines[5m]) > 10'
+                severity: warning
+                for: 5m
+                comments: |
+                  A threshold of 100/s only catches catastrophic leaks (30k goroutines in 5m). 10/s catches gradual leaks (~3k in 5m).
+                  Adjust based on your application's expected concurrency patterns.
+
       - name: Ruby
         logo: /images/services/ruby.svg
         exporters:
@@ -3411,6 +3881,9 @@ groups:
             slug: ruby-exporter
             doc_url: https://github.com/discourse/prometheus_exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
               - name: Ruby heap live slots high
                 description: Ruby heap has too many live slots (> 500k), heap bloat
                 query: 'ruby_heap_live_slots > 500000'
@@ -3430,6 +3903,10 @@ groups:
                 for: 5m
                 comments: |
                   Major GC rate > 5/s only fires if the app is essentially non-functional. Threshold of 2/s provides earlier detection.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Ruby RSS high
                 description: Ruby process RSS is high (> 1GB)
                 query: 'ruby_rss > 1e9'
@@ -3448,24 +3925,14 @@ groups:
             slug: python-exporter
             doc_url: https://github.com/prometheus/client_python
             rules:
+              #
+              # Resource saturation (USE)
+              #
               - name: Python GC objects uncollectable
                 description: Python has uncollectable objects ({{ $value }}), potential memory leak via reference cycles
                 query: 'increase(python_gc_objects_uncollectable_total[5m]) > 1'
                 severity: warning
                 for: 5m
-              - name: Python GC collections high
-                description: Python GC is collecting too many objects (> 10k/s), high allocation pressure
-                query: 'rate(python_gc_objects_collected_total[5m]) > 10000'
-                severity: warning
-                for: 5m
-              - name: Python file descriptors exhaustion
-                description: Python process is running out of file descriptors (> 90% used)
-                query: '(process_open_fds / process_max_fds) * 100 > 90 and process_max_fds > 0'
-                severity: warning
-                for: 5m
-                comments: |
-                  process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not Python-specific.
-                  This alert will also fire for Go, JVM, or any process exposing these metrics.
               - name: Python GC generation 2 collections high
                 description: Python full GC (generation 2) is running too frequently, indicating memory pressure
                 query: 'rate(python_gc_collections_total{generation="2"}[5m]) > 1'
@@ -3480,6 +3947,23 @@ groups:
                 for: 5m
                 comments: |
                   Threshold is a rough default. Adjust based on your application's expected memory footprint.
+              - name: Python file descriptors exhaustion
+                description: Python process is running out of file descriptors (> 90% used)
+                query: '(process_open_fds / process_max_fds) * 100 > 90 and process_max_fds > 0'
+                severity: warning
+                for: 5m
+                comments: |
+                  process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not Python-specific.
+                  This alert will also fire for Go, JVM, or any process exposing these metrics.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Python GC collections high
+                description: Python GC is collecting too many objects (> 10k/s), high allocation pressure
+                query: 'rate(python_gc_objects_collected_total[5m]) > 10000'
+                severity: warning
+                for: 5m
 
       - name: Sidekiq
         logo: /images/services/sidekiq.svg
@@ -3488,15 +3972,18 @@ groups:
             slug: strech-sidekiq-exporter
             doc_url: https://github.com/Strech/sidekiq-prometheus-exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
+              - name: Sidekiq scheduling latency too high
+                description: Sidekiq jobs are taking more than 1min to be picked up. Users may be seeing delays in background processing.
+                query: "max(sidekiq_queue_latency_seconds) > 60"
+                severity: critical
               - name: Sidekiq queue size
                 description: Sidekiq queue {{ $labels.name }} is growing ({{ $value }} enqueued jobs)
                 query: "sidekiq_queue_enqueued_jobs > 100"
                 severity: warning
                 for: 1m
-              - name: Sidekiq scheduling latency too high
-                description: Sidekiq jobs are taking more than 1min to be picked up. Users may be seeing delays in background processing.
-                query: "max(sidekiq_queue_latency_seconds) > 60"
-                severity: critical
 
   - name: Data engineering
     services:
@@ -3507,11 +3994,34 @@ groups:
             slug: flink-prometheus-reporter
             doc_url: https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/metric_reporters/
             rules:
+              #
+              # Availability
+              #
               - name: Flink job is not running
                 description: "No Flink jobs are currently running. All jobs may have failed or been cancelled."
                 query: "flink_jobmanager_numRunningJobs == 0"
                 severity: critical
                 for: 1m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Flink TaskManager heap memory high
+                description: "Flink TaskManager {{ $labels.instance }} heap memory usage is above 90%."
+                query: "flink_taskmanager_Status_JVM_Memory_Heap_Used / flink_taskmanager_Status_JVM_Memory_Heap_Max > 0.9 and flink_taskmanager_Status_JVM_Memory_Heap_Max > 0"
+                severity: warning
+                for: 5m
+                comments: |
+                  Flink TaskManagers manage their own memory pool. High JVM heap usage (outside managed memory) may indicate memory leaks or misconfiguration.
+              - name: Flink JobManager heap memory high
+                description: "Flink JobManager {{ $labels.instance }} heap memory usage is above 90%."
+                query: "flink_jobmanager_Status_JVM_Memory_Heap_Used / flink_jobmanager_Status_JVM_Memory_Heap_Max > 0.9 and flink_jobmanager_Status_JVM_Memory_Heap_Max > 0"
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Flink no TaskManagers registered
                 description: "No TaskManagers are registered with the JobManager. The cluster has no processing capacity."
                 query: "flink_jobmanager_numRegisteredTaskManagers == 0"
@@ -3558,18 +4068,6 @@ groups:
                 for: 5m
                 comments: |
                   Fires when a task spends more than 500ms/sec backpressured. This indicates the task cannot keep up with upstream data rate.
-              - name: Flink TaskManager heap memory high
-                description: "Flink TaskManager {{ $labels.instance }} heap memory usage is above 90%."
-                query: "flink_taskmanager_Status_JVM_Memory_Heap_Used / flink_taskmanager_Status_JVM_Memory_Heap_Max > 0.9 and flink_taskmanager_Status_JVM_Memory_Heap_Max > 0"
-                severity: warning
-                for: 5m
-                comments: |
-                  Flink TaskManagers manage their own memory pool. High JVM heap usage (outside managed memory) may indicate memory leaks or misconfiguration.
-              - name: Flink JobManager heap memory high
-                description: "Flink JobManager {{ $labels.instance }} heap memory usage is above 90%."
-                query: "flink_jobmanager_Status_JVM_Memory_Heap_Used / flink_jobmanager_Status_JVM_Memory_Heap_Max > 0.9 and flink_jobmanager_Status_JVM_Memory_Heap_Max > 0"
-                severity: warning
-                for: 5m
               - name: Flink TaskManager GC time high
                 description: "Flink TaskManager {{ $labels.instance }} is spending more than 10% of time in garbage collection."
                 query: "deriv(flink_taskmanager_Status_JVM_GarbageCollector_All_Time[5m]) > 100"
@@ -3599,11 +4097,36 @@ groups:
               Metric names from PrometheusServlet include a dynamic namespace (application ID), making static PromQL queries challenging.
               Configuration: spark.metrics.conf.*.sink.prometheusServlet.class=org.apache.spark.metrics.sink.PrometheusServlet
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Spark worker memory exhausted
+                description: "Spark worker {{ $labels.instance }} has no free memory ({{ $value }}MB free)."
+                query: "metrics_worker_memFree_MB_Value == 0"
+                severity: warning
+                for: 2m
+              - name: Spark executor high disk spill
+                description: "Spark executor {{ $labels.executor_id }} is spilling data to disk. Consider increasing executor memory."
+                query: "metrics_executor_diskUsed_bytes > 1e9"
+                severity: warning
+                for: 5m
+                comments: |
+                  diskUsed is a gauge, not a counter — do not use rate(). Threshold of 1GB is a rough default.
+                  Disk spilling indicates insufficient memory for the workload.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Spark no alive workers
                 description: "No Spark workers are alive. The cluster has no processing capacity."
                 query: "metrics_master_aliveWorkers_Value == 0"
                 severity: critical
                 for: 1m
+              - name: Spark executor all tasks failing
+                description: "Spark executor {{ $labels.executor_id }} has only failing tasks ({{ $value }} failed, 0 completed)."
+                query: "metrics_executor_failedTasks_total > 0 and metrics_executor_completedTasks_total == 0"
+                severity: critical
+                for: 5m
               - name: Spark too many waiting apps
                 description: "Spark has {{ $value }} applications waiting for resources."
                 query: "metrics_master_waitingApps_Value > 10"
@@ -3611,11 +4134,6 @@ groups:
                 for: 5m
                 comments: |
                   Adjust the threshold based on your cluster's typical queuing behavior.
-              - name: Spark worker memory exhausted
-                description: "Spark worker {{ $labels.instance }} has no free memory ({{ $value }}MB free)."
-                query: "metrics_worker_memFree_MB_Value == 0"
-                severity: warning
-                for: 2m
               - name: Spark worker cores exhausted
                 description: "Spark worker {{ $labels.instance }} has no free cores."
                 query: "metrics_worker_coresFree_Value == 0"
@@ -3631,24 +4149,11 @@ groups:
                 comments: |
                   Fires when more than 10% of executor time is spent in garbage collection.
                   This metric comes from the PrometheusResource endpoint (/metrics/executors/prometheus/).
-              - name: Spark executor all tasks failing
-                description: "Spark executor {{ $labels.executor_id }} has only failing tasks ({{ $value }} failed, 0 completed)."
-                query: "metrics_executor_failedTasks_total > 0 and metrics_executor_completedTasks_total == 0"
-                severity: critical
-                for: 5m
               - name: Spark executor high task failure rate
                 description: "Spark executor {{ $labels.executor_id }} has a task failure rate above 10%."
                 query: "metrics_executor_failedTasks_total / metrics_executor_totalTasks_total > 0.1 and metrics_executor_totalTasks_total > 0"
                 severity: warning
                 for: 5m
-              - name: Spark executor high disk spill
-                description: "Spark executor {{ $labels.executor_id }} is spilling data to disk. Consider increasing executor memory."
-                query: "metrics_executor_diskUsed_bytes > 1e9"
-                severity: warning
-                for: 5m
-                comments: |
-                  diskUsed is a gauge, not a counter — do not use rate(). Threshold of 1GB is a rough default.
-                  Disk spilling indicates insufficient memory for the workload.
 
       - name: Hadoop
         logo: /images/services/hadoop.svg
@@ -3657,7 +4162,9 @@ groups:
             slug: jmx_exporter
             doc_url: https://github.com/prometheus/jmx_exporter
             rules:
-              # Alert rule for NameNode availability
+              #
+              # Availability
+              #
               - name: Hadoop Name Node Down
                 query: up{job="hadoop-namenode"} == 0
                 for: 5m
@@ -3680,27 +4187,25 @@ groups:
                   Rename job="hadoop-resourcemanager" to match the actual job name in your Prometheus scrape config.
 
               # Alert rule for DataNode status
-              - name: Hadoop Data Node Out Of Service
-                query: hadoop_namenode_numdeaddatanodes > 0
-                for: 10m
-                severity: warning
-                description: "The Hadoop DataNode is not sending heartbeats."
-
-              # Alert rule for low HDFS disk space
-              - name: Hadoop HDFS Disk Space Low
-                query: 100 * hadoop_namenode_capacityremaining / clamp_min(hadoop_namenode_capacitytotal, 1) < 20
-                for: 15m
-                severity: warning
-                description: "Available HDFS disk space is running low."
-
-              # Alert rule for excessive MapReduce task failures
-              - name: Hadoop Map Reduce Task Failures
-                query: increase(hadoop_mapreduce_task_failures_total[1h]) > 100
-                for: 10m
+              - name: Hadoop HDFS Missing Blocks
+                description: HDFS has one or more blocks with no surviving replica, meaning permanent data loss has occurred.
+                query: "max without(job,name)(hadoop_namenode_missingblocks) > 0"
                 severity: critical
-                description: "There is an unusually high number of MapReduce task failures."
+                for: 5m
 
-              # Alert rule for high ResourceManager memory usage
+              #
+              # Resource saturation (USE)
+              #
+              - name: Hadoop Node Manager CPU High
+                description: YARN NodeManager CPU utilization is above 80%, which can degrade container scheduling and task execution on this node.
+                query: "max without(job,name)(100*hadoop_nodemanager_nodecpuutilization) > 80"
+                severity: warning
+                for: 15m
+              - name: Hadoop Resource Manager vCore Usage High
+                description: YARN ResourceManager has allocated more than 80% of cluster vCores, indicating the cluster is nearly out of CPU scheduling capacity.
+                query: "max without(job,name)(100*hadoop_resourcemanager_allocatedvcores/clamp_min(hadoop_resourcemanager_availablevcores+hadoop_resourcemanager_allocatedvcores,1)) > 80"
+                severity: warning
+                for: 15m
               - name: Hadoop Resource Manager Memory High
                 query: 100 * hadoop_resourcemanager_allocatedmb / clamp_min(hadoop_resourcemanager_availablemb + hadoop_resourcemanager_allocatedmb, 1) > 80
                 for: 15m
@@ -3708,6 +4213,44 @@ groups:
                 description: "The Hadoop ResourceManager is approaching its memory limit."
 
               # Alert rule for high YARN container allocation failures
+              - name: Hadoop HBase Region Server Heap Low
+                query: hadoop_hbase_region_server_heap_bytes / hadoop_hbase_region_server_max_heap_bytes > 0.8 and hadoop_hbase_region_server_max_heap_bytes > 0
+                for: 10m
+                severity: warning
+                description: "HBase Region Servers are running low on heap space."
+
+              # Alert rule for high HBase Write Requests latency
+              - name: Hadoop Node Manager Memory High
+                description: YARN NodeManager has allocated more than 80% of its available memory, risking container scheduling failures on this node.
+                query: "max without(job,name)(100*hadoop_nodemanager_allocatedgb/clamp_min(hadoop_nodemanager_availablegb+hadoop_nodemanager_allocatedgb,1)) > 80"
+                severity: warning
+                for: 15m
+              - name: Hadoop HDFS Disk Space Low
+                query: 100 * hadoop_namenode_capacityremaining / clamp_min(hadoop_namenode_capacitytotal, 1) < 20
+                for: 15m
+                severity: warning
+                description: "Available HDFS disk space is running low."
+
+              # Alert rule for excessive MapReduce task failures
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Hadoop Map Reduce Task Failures
+                query: increase(hadoop_mapreduce_task_failures_total[1h]) > 100
+                for: 10m
+                severity: critical
+                description: "There is an unusually high number of MapReduce task failures."
+
+              # Alert rule for high ResourceManager memory usage
+              # Alert rule for NameNode availability
+              - name: Hadoop Data Node Out Of Service
+                query: hadoop_namenode_numdeaddatanodes > 0
+                for: 10m
+                severity: warning
+                description: "The Hadoop DataNode is not sending heartbeats."
+
+              # Alert rule for low HDFS disk space
               - name: Hadoop YARN Container Allocation Failures
                 query: increase(hadoop_yarn_container_allocation_failures_total[1h]) > 10
                 for: 10m
@@ -3722,43 +4265,16 @@ groups:
                 description: "The HBase cluster has an unusually high number of regions."
 
               # Alert rule for low HBase region server heap space
-              - name: Hadoop HBase Region Server Heap Low
-                query: hadoop_hbase_region_server_heap_bytes / hadoop_hbase_region_server_max_heap_bytes > 0.8 and hadoop_hbase_region_server_max_heap_bytes > 0
-                for: 10m
-                severity: warning
-                description: "HBase Region Servers are running low on heap space."
-
-              # Alert rule for high HBase Write Requests latency
               - name: Hadoop HBase Write Requests Latency High
                 query: hadoop_hbase_write_requests_latency_seconds > 0.5
                 for: 10m
                 severity: warning
                 description: "HBase Write Requests are experiencing high latency."
-              - name: Hadoop HDFS Missing Blocks
-                description: HDFS has one or more blocks with no surviving replica, meaning permanent data loss has occurred.
-                query: "max without(job,name)(hadoop_namenode_missingblocks) > 0"
-                severity: critical
-                for: 5m
               - name: Hadoop HDFS Volume Failures
                 description: One or more HDFS DataNode storage volumes have failed since the DataNode last started, which is an early sign of failing disks.
                 query: "max without(job,name)(hadoop_namenode_volumefailurestotal) > 0"
                 severity: warning
                 for: 10m
-              - name: Hadoop Node Manager CPU High
-                description: YARN NodeManager CPU utilization is above 80%, which can degrade container scheduling and task execution on this node.
-                query: "max without(job,name)(100*hadoop_nodemanager_nodecpuutilization) > 80"
-                severity: warning
-                for: 15m
-              - name: Hadoop Node Manager Memory High
-                description: YARN NodeManager has allocated more than 80% of its available memory, risking container scheduling failures on this node.
-                query: "max without(job,name)(100*hadoop_nodemanager_allocatedgb/clamp_min(hadoop_nodemanager_availablegb+hadoop_nodemanager_allocatedgb,1)) > 80"
-                severity: warning
-                for: 15m
-              - name: Hadoop Resource Manager vCore Usage High
-                description: YARN ResourceManager has allocated more than 80% of cluster vCores, indicating the cluster is nearly out of CPU scheduling capacity.
-                query: "max without(job,name)(100*hadoop_resourcemanager_allocatedvcores/clamp_min(hadoop_resourcemanager_availablevcores+hadoop_resourcemanager_allocatedvcores,1)) > 80"
-                severity: warning
-                for: 15m
 
   - name: Orchestrators
     services:
@@ -3769,19 +4285,28 @@ groups:
             slug: kubestate-exporter
             doc_url: https://github.com/kubernetes/kube-state-metrics/tree/master/docs
             rules:
-              - name: Kubernetes Node not ready
-                description: Node {{ $labels.node }} has been unready for a long time
-                query: 'kube_node_status_condition{condition="Ready",status="true"} == 0'
+              #
+              # Availability
+              #
+              - name: Kubernetes StatefulSet down
+                description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} went down
+                query: "kube_statefulset_replicas > 0 and kube_statefulset_replicas != kube_statefulset_status_replicas_ready and changes(kube_statefulset_status_replicas_updated[10m]) == 0"
                 severity: critical
-                for: 10m
-              - name: Kubernetes Node scheduling disabled
-                description: Node {{ $labels.node }} has been marked as unschedulable for more than 30 minutes.
-                query: 'kube_node_spec_taint{key="node.kubernetes.io/unschedulable"} == 1'
+                for: 3m
+              - name: Kubernetes Container oom killer
+                description: "Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 10 minutes."
+                query: '(kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1'
                 severity: warning
-                for: 30m
+              - name: Kubernetes CronJob too long
+                description: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
+                query: "kube_job_status_start_time > 0 and absent(kube_job_status_completion_time) and (time() - kube_job_status_start_time) > 3600"
+                severity: warning
                 comments: |
-                  Kubernetes Node with disabled schedules are fine.
-                  This alarm can be useful to get warned if there are nodes which are longer unscheduled.
+                  Threshold should be customized for each cronjob name.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Kubernetes Node memory pressure
                 description: "Node {{ $labels.node }} has MemoryPressure condition"
                 query: 'kube_node_status_condition{condition="MemoryPressure",status="true"} == 1'
@@ -3792,20 +4317,102 @@ groups:
                 query: 'kube_node_status_condition{condition="DiskPressure",status="true"} == 1'
                 severity: critical
                 for: 2m
+              - name: Kubernetes Volume out of disk space
+                description: Volume is almost full (< 10% left)
+                query: "kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes * 100 < 10 and kubelet_volume_stats_capacity_bytes > 0"
+                severity: critical
+                for: 2m
+              - name: Kubernetes Volume inodes full in four days
+                description: PersistentVolume claimed by {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is expected to run out of free inodes within four days at the current rate.
+                query: "predict_linear(kubelet_volume_stats_inodes_free[6h:5m], 4 * 24 * 3600) < 0"
+                severity: critical
+              - name: Kubernetes Volume out of inodes
+                description: PersistentVolume claimed by {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 3% of its inodes free. A volume can run out of inodes (too many small files) even while free bytes remain available.
+                query: "kubelet_volume_stats_inodes_free / kubelet_volume_stats_inodes < 0.03 and kubelet_volume_stats_inodes > 0"
+                severity: warning
+                for: 2m
               - name: Kubernetes Node network unavailable
                 description: "Node {{ $labels.node }} has NetworkUnavailable condition"
                 query: 'kube_node_status_condition{condition="NetworkUnavailable",status="true"} == 1'
                 severity: critical
                 for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Kubernetes Node not ready
+                description: Node {{ $labels.node }} has been unready for a long time
+                query: 'kube_node_status_condition{condition="Ready",status="true"} == 0'
+                severity: critical
+                for: 10m
+              - name: Kubernetes CronJob failing
+                description: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is failing"
+                query: "(kube_cronjob_status_last_schedule_time > kube_cronjob_status_last_successful_time) AND (kube_cronjob_status_active == 0) AND (kube_cronjob_spec_suspend == 0)"
+                severity: critical
+              - name: Kubernetes PersistentVolume error
+                description: "Persistent volume {{ $labels.persistentvolume }} is in bad state"
+                query: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending"} > 0'
+                severity: critical
+              - name: Kubernetes Pod not healthy
+                description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-running state for longer than 15 minutes.
+                query: 'sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"}) > 0'
+                severity: critical
+                for: 15m
+              # Keyed on the CrashLoopBackOff waiting reason rather than a restart-count threshold:
+              # Kubernetes' exponential backoff (up to 5m between restarts) means a real crash loop
+              # won't restart 4+ times per minute after the first minute or two.
+              - name: Kubernetes Deployment generation mismatch
+                description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has failed but has not been rolled back.
+                query: "kube_deployment_status_observed_generation != kube_deployment_metadata_generation"
+                severity: critical
+                for: 10m
+              - name: Kubernetes StatefulSet generation mismatch
+                description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has failed but has not been rolled back.
+                query: "kube_statefulset_status_observed_generation != kube_statefulset_metadata_generation"
+                severity: critical
+                for: 10m
+              - name: Kubernetes Job slow completion
+                description: Kubernetes Job {{ $labels.namespace }}/{{ $labels.job_name }} did not complete in time.
+                query: "kube_job_spec_completions - kube_job_status_succeeded - kube_job_status_failed > 0"
+                severity: critical
+                for: 12h
+              - name: Kubernetes API server errors
+                description: "Kubernetes API server is experiencing {{ $value | humanize }}% error rate"
+                query: 'sum(rate(apiserver_request_total{job="apiserver",code=~"(?:5..)"}[1m])) by (instance, job) / sum(rate(apiserver_request_total{job="apiserver"}[1m])) by (instance, job) * 100 > 3 and sum(rate(apiserver_request_total{job="apiserver"}[1m])) by (instance, job) > 0'
+                severity: critical
+                for: 2m
+              - name: Kubernetes API client errors
+                description: "Kubernetes API client is experiencing {{ $value | humanize }}% error rate"
+                query: '(sum(rate(rest_client_requests_total{code=~"(4|5).."}[1m])) by (instance, job) / sum(rate(rest_client_requests_total[1m])) by (instance, job)) * 100 > 1 and sum(rate(rest_client_requests_total[1m])) by (instance, job) > 0'
+                severity: critical
+                for: 2m
+                comments: |
+                  Includes 4xx errors alongside 5xx. Some clients use GET requests to check object
+                  existence, and a 404 is expected in that case, not a real error. Narrow the regex to
+                  "5.." if 4xx responses cause noise.
+              - name: Kubernetes kube-state-metrics list/watch errors
+                description: kube-state-metrics is failing to list or watch objects from the Kubernetes API server, which means every other kube-state-metrics-based alert may silently stop firing because its data has gone stale or missing.
+                query: '(rate(kube_state_metrics_list_total{result="error"}[5m]) / rate(kube_state_metrics_list_total[5m]) > 0.01 and rate(kube_state_metrics_list_total[5m]) > 0) or (rate(kube_state_metrics_watch_total{result="error"}[5m]) / rate(kube_state_metrics_watch_total[5m]) > 0.01 and rate(kube_state_metrics_watch_total[5m]) > 0)'
+                severity: critical
+                for: 5m
+              - name: Kubernetes API server terminating requests
+                description: The Kubernetes API server is terminating {{ $value | humanizePercentage }} of incoming requests, indicating it is shedding load under overload (e.g. via priority and fairness flow control) rather than just returning error responses.
+                query: "sum(rate(apiserver_request_terminations_total[10m])) / (sum(rate(apiserver_request_total[10m])) + sum(rate(apiserver_request_terminations_total[10m]))) > 0.20"
+                severity: critical
+                for: 2m
+              - name: Kubernetes Node scheduling disabled
+                description: Node {{ $labels.node }} has been marked as unschedulable for more than 30 minutes.
+                query: 'kube_node_spec_taint{key="node.kubernetes.io/unschedulable"} == 1'
+                severity: warning
+                for: 30m
+                comments: |
+                  Kubernetes Node with disabled schedules are fine.
+                  This alarm can be useful to get warned if there are nodes which are longer unscheduled.
               - name: Kubernetes Node out of pod capacity
                 description: "Node {{ $labels.node }} is out of pod capacity"
                 query: 'sum by (node) ((kube_pod_status_phase{phase="Running"} == 1) + on(uid, instance) group_left(node) (0 * kube_pod_info{pod_template_hash=""})) / sum by (node) (kube_node_status_allocatable{resource="pods"}) * 100 > 90'
                 severity: warning
                 for: 2m
-              - name: Kubernetes Container oom killer
-                description: "Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} has been OOMKilled {{ $value }} times in the last 10 minutes."
-                query: '(kube_pod_container_status_restarts_total - kube_pod_container_status_restarts_total offset 10m >= 1) and ignoring (reason) min_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[10m]) == 1'
-                severity: warning
               - name: Kubernetes Job failed
                 description: "Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete"
                 query: "kube_job_status_failed > 0"
@@ -3814,10 +4421,6 @@ groups:
                 description: "Job {{ $labels.namespace }}/{{ $labels.job_name }} did not start for 10 minutes"
                 query: "kube_job_status_active == 0 and kube_job_status_failed == 0 and kube_job_status_succeeded == 0 and (time() - kube_job_status_start_time) > 600"
                 severity: warning
-              - name: Kubernetes CronJob failing
-                description: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is failing"
-                query: "(kube_cronjob_status_last_schedule_time > kube_cronjob_status_last_successful_time) AND (kube_cronjob_status_active == 0) AND (kube_cronjob_spec_suspend == 0)"
-                severity: critical
               - name: Kubernetes CronJob suspended
                 description: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is suspended"
                 query: "kube_cronjob_spec_suspend != 0"
@@ -3827,24 +4430,10 @@ groups:
                 query: 'kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1'
                 severity: warning
                 for: 2m
-              - name: Kubernetes Volume out of disk space
-                description: Volume is almost full (< 10% left)
-                query: "kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes * 100 < 10 and kubelet_volume_stats_capacity_bytes > 0"
-                severity: critical
-                for: 2m
               - name: Kubernetes Volume full in four days
                 description: "Volume under {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is expected to fill up within four days. Currently {{ $value | humanize }}% is available."
                 query: "predict_linear(kubelet_volume_stats_available_bytes[6h:5m], 4 * 24 * 3600) < 0"
                 severity: warning
-              - name: Kubernetes PersistentVolume error
-                description: "Persistent volume {{ $labels.persistentvolume }} is in bad state"
-                query: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending"} > 0'
-                severity: critical
-              - name: Kubernetes StatefulSet down
-                description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} went down
-                query: "kube_statefulset_replicas > 0 and kube_statefulset_replicas != kube_statefulset_status_replicas_ready and changes(kube_statefulset_status_replicas_updated[10m]) == 0"
-                severity: critical
-                for: 3m
               - name: Kubernetes HPA scale inability
                 description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} is unable to scale
                 query: '(kube_horizontalpodautoscaler_spec_max_replicas - kube_horizontalpodautoscaler_status_desired_replicas) * on (horizontalpodautoscaler,namespace) (kube_horizontalpodautoscaler_status_condition{condition="ScalingLimited", status="true"} == 1) == 0'
@@ -3854,23 +4443,6 @@ groups:
                 description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} is unable to collect metrics
                 query: 'kube_horizontalpodautoscaler_status_condition{status="false", condition="ScalingActive"} == 1'
                 severity: warning
-              - name: Kubernetes HPA scale maximum
-                description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} has hit maximum number of desired pods
-                query: "(kube_horizontalpodautoscaler_status_desired_replicas >= kube_horizontalpodautoscaler_spec_max_replicas) and (kube_horizontalpodautoscaler_spec_max_replicas > 1) and (kube_horizontalpodautoscaler_spec_min_replicas != kube_horizontalpodautoscaler_spec_max_replicas)"
-                severity: info
-                for: 2m
-              - name: Kubernetes HPA underutilized
-                description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} is constantly at minimum replicas for 50% of the time. Potential cost saving here.
-                query: "max(quantile_over_time(0.5, kube_horizontalpodautoscaler_status_desired_replicas[1d]) == kube_horizontalpodautoscaler_spec_min_replicas) by (horizontalpodautoscaler) > 3" # allow minimum 3 replicas running
-                severity: info
-              - name: Kubernetes Pod not healthy
-                description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-running state for longer than 15 minutes.
-                query: 'sum by (namespace, pod) (kube_pod_status_phase{phase=~"Pending|Unknown|Failed"}) > 0'
-                severity: critical
-                for: 15m
-              # Keyed on the CrashLoopBackOff waiting reason rather than a restart-count threshold:
-              # Kubernetes' exponential backoff (up to 5m between restarts) means a real crash loop
-              # won't restart 4+ times per minute after the first minute or two.
               - name: Kubernetes pod crash looping
                 description: Pod {{ $labels.namespace }}/{{ $labels.pod }} is crash looping
                 query: 'max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}[5m]) >= 1'
@@ -3891,16 +4463,6 @@ groups:
                 query: "kube_statefulset_status_replicas_ready != kube_statefulset_status_replicas"
                 severity: warning
                 for: 10m
-              - name: Kubernetes Deployment generation mismatch
-                description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has failed but has not been rolled back.
-                query: "kube_deployment_status_observed_generation != kube_deployment_metadata_generation"
-                severity: critical
-                for: 10m
-              - name: Kubernetes StatefulSet generation mismatch
-                description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has failed but has not been rolled back.
-                query: "kube_statefulset_status_observed_generation != kube_statefulset_metadata_generation"
-                severity: critical
-                for: 10m
               - name: Kubernetes StatefulSet update not rolled out
                 description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.
                 query: "max without (revision) (kube_statefulset_status_current_revision unless kube_statefulset_status_update_revision) * (kube_statefulset_replicas != kube_statefulset_status_replicas_updated)"
@@ -3920,39 +4482,6 @@ groups:
                 query: "kube_daemonset_status_number_misscheduled > 0"
                 severity: warning
                 for: 1m
-              - name: Kubernetes CronJob too long
-                description: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more than 1h to complete.
-                query: "kube_job_status_start_time > 0 and absent(kube_job_status_completion_time) and (time() - kube_job_status_start_time) > 3600"
-                severity: warning
-                comments: |
-                  Threshold should be customized for each cronjob name.
-              - name: Kubernetes Job slow completion
-                description: Kubernetes Job {{ $labels.namespace }}/{{ $labels.job_name }} did not complete in time.
-                query: "kube_job_spec_completions - kube_job_status_succeeded - kube_job_status_failed > 0"
-                severity: critical
-                for: 12h
-              - name: Kubernetes API server errors
-                description: "Kubernetes API server is experiencing {{ $value | humanize }}% error rate"
-                query: 'sum(rate(apiserver_request_total{job="apiserver",code=~"(?:5..)"}[1m])) by (instance, job) / sum(rate(apiserver_request_total{job="apiserver"}[1m])) by (instance, job) * 100 > 3 and sum(rate(apiserver_request_total{job="apiserver"}[1m])) by (instance, job) > 0'
-                severity: critical
-                for: 2m
-              - name: Kubernetes API client errors
-                description: "Kubernetes API client is experiencing {{ $value | humanize }}% error rate"
-                query: '(sum(rate(rest_client_requests_total{code=~"(4|5).."}[1m])) by (instance, job) / sum(rate(rest_client_requests_total[1m])) by (instance, job)) * 100 > 1 and sum(rate(rest_client_requests_total[1m])) by (instance, job) > 0'
-                severity: critical
-                for: 2m
-                comments: |
-                  Includes 4xx errors alongside 5xx. Some clients use GET requests to check object
-                  existence, and a 404 is expected in that case, not a real error. Narrow the regex to
-                  "5.." if 4xx responses cause noise.
-              - name: Kubernetes client certificate expires next week
-                description: A client certificate used to authenticate to the apiserver is expiring next week.
-                query: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 7*24*60*60'
-                severity: warning
-              - name: Kubernetes client certificate expires soon
-                description: A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.
-                query: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 24*60*60'
-                severity: critical
               - name: Kubernetes API server latency
                 description: "Kubernetes API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}."
                 query: 'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!~"(?:CONNECT|WATCHLIST|WATCH|PROXY)"} [10m])) WITHOUT (subresource)) > 1'
@@ -3973,35 +4502,41 @@ groups:
                 query: "kube_poddisruptionbudget_status_desired_healthy - kube_poddisruptionbudget_status_current_healthy > 0"
                 severity: warning
                 for: 10m
-              - name: Kubernetes Volume out of inodes
-                description: PersistentVolume claimed by {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 3% of its inodes free. A volume can run out of inodes (too many small files) even while free bytes remain available.
-                query: "kubelet_volume_stats_inodes_free / kubelet_volume_stats_inodes < 0.03 and kubelet_volume_stats_inodes > 0"
-                severity: warning
-                for: 2m
-              - name: Kubernetes Volume inodes full in four days
-                description: PersistentVolume claimed by {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is expected to run out of free inodes within four days at the current rate.
-                query: "predict_linear(kubelet_volume_stats_inodes_free[6h:5m], 4 * 24 * 3600) < 0"
-                severity: critical
               - name: Kubernetes version mismatch
                 description: There are {{ $value }} different semantic versions of Kubernetes components running simultaneously, which may indicate a partial or stalled cluster upgrade.
                 query: 'count(count by (git_version) (label_replace(kubernetes_build_info, "git_version", "$1", "git_version", "(v[0-9]*\.[0-9]*\.[0-9]*).*"))) > 1'
                 severity: warning
                 for: 10m
-              - name: Kubernetes kube-state-metrics list/watch errors
-                description: kube-state-metrics is failing to list or watch objects from the Kubernetes API server, which means every other kube-state-metrics-based alert may silently stop firing because its data has gone stale or missing.
-                query: '(rate(kube_state_metrics_list_total{result="error"}[5m]) / rate(kube_state_metrics_list_total[5m]) > 0.01 and rate(kube_state_metrics_list_total[5m]) > 0) or (rate(kube_state_metrics_watch_total{result="error"}[5m]) / rate(kube_state_metrics_watch_total[5m]) > 0.01 and rate(kube_state_metrics_watch_total[5m]) > 0)'
-                severity: critical
-                for: 5m
-              - name: Kubernetes API server terminating requests
-                description: The Kubernetes API server is terminating {{ $value | humanizePercentage }} of incoming requests, indicating it is shedding load under overload (e.g. via priority and fairness flow control) rather than just returning error responses.
-                query: "sum(rate(apiserver_request_terminations_total[10m])) / (sum(rate(apiserver_request_total[10m])) + sum(rate(apiserver_request_terminations_total[10m]))) > 0.20"
-                severity: critical
+              - name: Kubernetes HPA scale maximum
+                description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} has hit maximum number of desired pods
+                query: "(kube_horizontalpodautoscaler_status_desired_replicas >= kube_horizontalpodautoscaler_spec_max_replicas) and (kube_horizontalpodautoscaler_spec_max_replicas > 1) and (kube_horizontalpodautoscaler_spec_min_replicas != kube_horizontalpodautoscaler_spec_max_replicas)"
+                severity: info
                 for: 2m
+              - name: Kubernetes HPA underutilized
+                description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} is constantly at minimum replicas for 50% of the time. Potential cost saving here.
+                query: "max(quantile_over_time(0.5, kube_horizontalpodautoscaler_status_desired_replicas[1d]) == kube_horizontalpodautoscaler_spec_min_replicas) by (horizontalpodautoscaler) > 3" # allow minimum 3 replicas running
+                severity: info
+
+              #
+              # Capacity and trend
+              #
               - name: Kubernetes ResourceQuota exceeded
                 description: Namespace {{ $labels.namespace }} is using more of its {{ $labels.resource }} ResourceQuota than the configured hard limit ({{ $value | humanizePercentage }} of quota), indicating a misconfiguration or inconsistency between actual usage and the enforced quota.
                 query: 'kube_resourcequota{type="used"} / ignoring(type) (kube_resourcequota{type="hard"} > 0) > 1'
                 severity: warning
                 for: 10m
+
+              #
+              # Info, security, and config
+              #
+              - name: Kubernetes client certificate expires soon
+                description: A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.
+                query: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 24*60*60'
+                severity: critical
+              - name: Kubernetes client certificate expires next week
+                description: A client certificate used to authenticate to the apiserver is expiring next week.
+                query: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"} > 0 and histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m]))) < 7*24*60*60'
+                severity: warning
 
       - name: Nomad
         logo: /images/services/nomad.svg
@@ -4009,6 +4544,9 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Nomad job failed
                 description: "Nomad job {{ $labels.job }} has {{ $value }} failed allocations."
                 query: "nomad_nomad_job_summary_failed > 0"
@@ -4034,11 +4572,9 @@ groups:
             slug: consul-exporter
             doc_url: https://github.com/prometheus/consul_exporter
             rules:
-              - name: Consul service healthcheck failed
-                description: "Service: `{{ $labels.service_name }}` Healthcheck: `{{ $labels.service_id }}`"
-                query: "consul_catalog_service_node_healthy == 0"
-                severity: critical
-                for: 1m # allows a short service restart
+              #
+              # Availability
+              #
               - name: Consul missing master node
                 description: Numbers of consul raft peers should be 3, in order to preserve quorum.
                 query: "consul_raft_peers < 3"
@@ -4051,6 +4587,15 @@ groups:
                 description: A Consul agent is down
                 query: 'consul_health_node_status{status="critical"} == 1'
                 severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Consul service healthcheck failed
+                description: "Service: `{{ $labels.service_name }}` Healthcheck: `{{ $labels.service_id }}`"
+                query: "consul_catalog_service_node_healthy == 0"
+                severity: critical
+                for: 1m # allows a short service restart
               - name: Consul has no raft leader
                 description: The Consul raft cluster has no elected leader (according to {{ $labels.instance }}), meaning the cluster cannot process writes and is effectively unavailable.
                 query: "consul_raft_leader != 1"
@@ -4068,14 +4613,64 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
-              - name: Etcd insufficient Members
-                description: Etcd cluster should have an odd number of members
-                query: "count(etcd_server_id) % 2 == 0"
-                severity: critical
+              #
+              # Availability
+              #
               - name: Etcd no Leader
                 description: Etcd cluster have no leader
                 query: "etcd_server_has_leader == 0"
                 severity: critical
+              - name: Etcd insufficient members for quorum
+                description: Only {{ $value }} etcd members are reachable, fewer than required for quorum; the cluster will reject writes until quorum is restored.
+                query: 'sum(up{job=~".*etcd.*"} == bool 1) without (instance) < ((count(up{job=~".*etcd.*"}) without (instance) + 1) / 2)'
+                severity: critical
+                for: 3m
+              - name: Etcd high fsync durations critical
+                description: Etcd WAL fsync duration is critically high, 99th percentile is over 1s, which can cause request timeouts and trigger leader elections.
+                query: "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le)) > 1"
+                severity: critical
+                for: 2m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Etcd high fsync durations
+                description: Etcd WAL fsync duration increasing, 99th percentile is over 0.5s
+                query: "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le)) > 0.5"
+                severity: warning
+                for: 2m
+              - name: Etcd high commit durations
+                description: Etcd commit duration increasing, 99th percentile is over 0.25s
+                query: "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le)) > 0.25"
+                severity: warning
+                for: 2m
+              - name: Etcd database high fragmentation ratio
+                description: Etcd database in-use size is below 50% of its allocated size ({{ $value | humanizePercentage }}), indicating fragmentation; run 'etcdctl defrag' to reclaim disk space.
+                query: "(last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600"
+                severity: warning
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Etcd insufficient Members
+                description: Etcd cluster should have an odd number of members
+                query: "count(etcd_server_id) % 2 == 0"
+                severity: critical
+              - name: Etcd high number of failed GRPC requests critical
+                description: More than 5% GRPC request failure detected in Etcd
+                query: 'sum(rate(grpc_server_handled_total{grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[1m])) BY (grpc_service, grpc_method) / sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0.05 and sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0'
+                severity: critical
+                for: 2m
+                comments: |
+                  Counts server-side failures only. NotFound, AlreadyExists and Cancelled are normal gRPC
+                  responses and are deliberately excluded from the error rate.
+              - name: Etcd high number of failed HTTP requests critical
+                description: More than 5% HTTP failure detected in Etcd
+                query: "sum(rate(etcd_http_failed_total[1m])) BY (method) / sum(rate(etcd_http_received_total[1m])) BY (method) > 0.05 and sum(rate(etcd_http_received_total[1m])) BY (method) > 0"
+                severity: critical
+                for: 2m
+                comments: "These etcd_http_* metrics are from the etcd v2 API and do not exist in etcd 3.x. Remove these rules if running etcd 3.x."
               - name: Etcd high number of leader changes
                 description: "Etcd leader changed {{ $value }} times during 10 minutes"
                 query: "increase(etcd_server_leader_changes_seen_total[10m]) > 2"
@@ -4084,14 +4679,6 @@ groups:
                 description: More than 1% GRPC request failure detected in Etcd
                 query: 'sum(rate(grpc_server_handled_total{grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[1m])) BY (grpc_service, grpc_method) / sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0.01 and sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0'
                 severity: warning
-                for: 2m
-                comments: |
-                  Counts server-side failures only. NotFound, AlreadyExists and Cancelled are normal gRPC
-                  responses and are deliberately excluded from the error rate.
-              - name: Etcd high number of failed GRPC requests critical
-                description: More than 5% GRPC request failure detected in Etcd
-                query: 'sum(rate(grpc_server_handled_total{grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[1m])) BY (grpc_service, grpc_method) / sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0.05 and sum(rate(grpc_server_handled_total[1m])) BY (grpc_service, grpc_method) > 0'
-                severity: critical
                 for: 2m
                 comments: |
                   Counts server-side failures only. NotFound, AlreadyExists and Cancelled are normal gRPC
@@ -4112,12 +4699,6 @@ groups:
                 severity: warning
                 for: 2m
                 comments: "These etcd_http_* metrics are from the etcd v2 API and do not exist in etcd 3.x. Remove these rules if running etcd 3.x."
-              - name: Etcd high number of failed HTTP requests critical
-                description: More than 5% HTTP failure detected in Etcd
-                query: "sum(rate(etcd_http_failed_total[1m])) BY (method) / sum(rate(etcd_http_received_total[1m])) BY (method) > 0.05 and sum(rate(etcd_http_received_total[1m])) BY (method) > 0"
-                severity: critical
-                for: 2m
-                comments: "These etcd_http_* metrics are from the etcd v2 API and do not exist in etcd 3.x. Remove these rules if running etcd 3.x."
               - name: Etcd HTTP requests slow
                 description: HTTP requests slowing down, 99th percentile is over 0.15s
                 query: "histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[1m])) > 0.15"
@@ -4134,16 +4715,6 @@ groups:
                 query: "increase(etcd_server_proposals_failed_total[1h]) > 5"
                 severity: warning
                 for: 2m
-              - name: Etcd high fsync durations
-                description: Etcd WAL fsync duration increasing, 99th percentile is over 0.5s
-                query: "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le)) > 0.5"
-                severity: warning
-                for: 2m
-              - name: Etcd high commit durations
-                description: Etcd commit duration increasing, 99th percentile is over 0.25s
-                query: "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) by (instance, le)) > 0.25"
-                severity: warning
-                for: 2m
               - name: Etcd peer communication failures
                 description: Etcd member is experiencing more than 0.01 failed peer sends per second to peer {{ $labels.To }}, which usually indicates the member is unreachable or network-partitioned.
                 query: "sum(rate(etcd_network_peer_sent_failures_total[1m])) by (To) > 0.01"
@@ -4151,11 +4722,10 @@ groups:
                 for: 2m
               # without (instance) keeps the count scoped per etcd cluster: several clusters often share
               # a job label (main and events), and aggregating across them both misfires and masks.
-              - name: Etcd insufficient members for quorum
-                description: Only {{ $value }} etcd members are reachable, fewer than required for quorum; the cluster will reject writes until quorum is restored.
-                query: 'sum(up{job=~".*etcd.*"} == bool 1) without (instance) < ((count(up{job=~".*etcd.*"}) without (instance) + 1) / 2)'
-                severity: critical
-                for: 3m
+
+              #
+              # Capacity and trend
+              #
               - name: Etcd database quota low space
                 description: Etcd database size is above 95% of the configured storage quota ({{ $value }}%); once the quota is reached, etcd stops accepting writes cluster-wide.
                 query: "(last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m])) * 100 > 95"
@@ -4166,16 +4736,6 @@ groups:
                 query: "predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes"
                 severity: warning
                 for: 10m
-              - name: Etcd database high fragmentation ratio
-                description: Etcd database in-use size is below 50% of its allocated size ({{ $value | humanizePercentage }}), indicating fragmentation; run 'etcdctl defrag' to reclaim disk space.
-                query: "(last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600"
-                severity: warning
-                for: 10m
-              - name: Etcd high fsync durations critical
-                description: Etcd WAL fsync duration is critically high, 99th percentile is over 1s, which can cause request timeouts and trigger leader elections.
-                query: "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le)) > 1"
-                severity: critical
-                for: 2m
 
       - name: OpenStack
         logo: /images/services/openstack.svg
@@ -4184,6 +4744,9 @@ groups:
             slug: openstack-exporter
             doc_url: https://github.com/openstack-exporter/openstack-exporter
             rules:
+              #
+              # Availability
+              #
               - name: OpenStack exporter down
                 description: The OpenStack exporter is down. OpenStack cloud metrics are no longer being collected.
                 query: 'up{job=~".*openstack.*"} == 0'
@@ -4206,6 +4769,10 @@ groups:
                 query: 'openstack_cinder_agent_state{adminState="enabled"} == 0'
                 severity: critical
                 for: 2m
+
+              #
+              # Resource saturation (USE)
+              #
               - name: OpenStack hypervisor high vCPU usage
                 description: "Hypervisor {{ $labels.hostname }} vCPU usage is above 90%"
                 query: 'openstack_nova_vcpus_used / openstack_nova_vcpus_available > 0.9 and openstack_nova_vcpus_available > 0'
@@ -4225,29 +4792,19 @@ groups:
                 query: 'openstack_nova_local_storage_used_bytes / openstack_nova_local_storage_available_bytes > 0.9 and openstack_nova_local_storage_available_bytes > 0'
                 severity: warning
                 for: 5m
-              - name: OpenStack Nova tenant vCPU quota nearly exhausted
-                description: "Tenant {{ $labels.tenant }} has used over 90% of its vCPU quota"
-                query: 'openstack_nova_limits_vcpus_used / openstack_nova_limits_vcpus_max > 0.9 and openstack_nova_limits_vcpus_max > 0'
-                severity: warning
-                comments: |
-                  A value of -1 for limits_vcpus_max means unlimited quota (no limit set).
-              - name: OpenStack Nova tenant memory quota nearly exhausted
-                description: "Tenant {{ $labels.tenant }} has used over 90% of its memory quota"
-                query: 'openstack_nova_limits_memory_used / openstack_nova_limits_memory_max > 0.9 and openstack_nova_limits_memory_max > 0'
-                severity: warning
-              - name: OpenStack Nova tenant instance quota nearly exhausted
-                description: "Tenant {{ $labels.tenant }} has used over 90% of its instance quota"
-                query: 'openstack_nova_limits_instances_used / openstack_nova_limits_instances_max > 0.9 and openstack_nova_limits_instances_max > 0'
-                severity: warning
-              - name: OpenStack Cinder tenant volume quota nearly exhausted
-                description: "Tenant {{ $labels.tenant }} has used over 90% of its volume storage quota"
-                query: 'openstack_cinder_limits_volume_used_gb / openstack_cinder_limits_volume_max_gb > 0.9 and openstack_cinder_limits_volume_max_gb > 0'
-                severity: warning
               - name: OpenStack Cinder pool low free capacity
                 description: "Cinder storage pool {{ $labels.name }} has less than 10% free capacity"
                 query: 'openstack_cinder_pool_capacity_free_gb / openstack_cinder_pool_capacity_total_gb < 0.1 and openstack_cinder_pool_capacity_total_gb > 0'
                 severity: warning
                 for: 5m
+              - name: OpenStack Neutron subnet IP pool exhaustion
+                description: "Subnet {{ $labels.subnet_name }} on network {{ $labels.network_name }} has used over 90% of its IP pool"
+                query: 'openstack_neutron_network_ip_availabilities_used / openstack_neutron_network_ip_availabilities_total > 0.9 and openstack_neutron_network_ip_availabilities_total > 0'
+                severity: warning
+
+              #
+              # Performance and errors (RED)
+              #
               - name: OpenStack Neutron floating IPs associated but not active
                 description: "{{ $value }} floating IPs are associated to a private IP but are not in ACTIVE state"
                 query: 'openstack_neutron_floating_ips_associated_not_active > 0'
@@ -4258,10 +4815,6 @@ groups:
                 query: 'openstack_neutron_routers_not_active > 0'
                 severity: warning
                 for: 5m
-              - name: OpenStack Neutron subnet IP pool exhaustion
-                description: "Subnet {{ $labels.subnet_name }} on network {{ $labels.network_name }} has used over 90% of its IP pool"
-                query: 'openstack_neutron_network_ip_availabilities_used / openstack_neutron_network_ip_availabilities_total > 0.9 and openstack_neutron_network_ip_availabilities_total > 0'
-                severity: warning
               - name: OpenStack Neutron ports without IPs
                 description: "{{ $value }} active ports have no IP addresses assigned"
                 query: 'openstack_neutron_ports_no_ips > 0'
@@ -4291,6 +4844,28 @@ groups:
                   This alert factors in the allocation ratio to compute effective capacity.
                   The threshold of 90% is a rough default. Adjust based on your allocation ratios and workload patterns.
 
+              #
+              # Capacity and trend
+              #
+              - name: OpenStack Nova tenant vCPU quota nearly exhausted
+                description: "Tenant {{ $labels.tenant }} has used over 90% of its vCPU quota"
+                query: 'openstack_nova_limits_vcpus_used / openstack_nova_limits_vcpus_max > 0.9 and openstack_nova_limits_vcpus_max > 0'
+                severity: warning
+                comments: |
+                  A value of -1 for limits_vcpus_max means unlimited quota (no limit set).
+              - name: OpenStack Nova tenant memory quota nearly exhausted
+                description: "Tenant {{ $labels.tenant }} has used over 90% of its memory quota"
+                query: 'openstack_nova_limits_memory_used / openstack_nova_limits_memory_max > 0.9 and openstack_nova_limits_memory_max > 0'
+                severity: warning
+              - name: OpenStack Nova tenant instance quota nearly exhausted
+                description: "Tenant {{ $labels.tenant }} has used over 90% of its instance quota"
+                query: 'openstack_nova_limits_instances_used / openstack_nova_limits_instances_max > 0.9 and openstack_nova_limits_instances_max > 0'
+                severity: warning
+              - name: OpenStack Cinder tenant volume quota nearly exhausted
+                description: "Tenant {{ $labels.tenant }} has used over 90% of its volume storage quota"
+                query: 'openstack_cinder_limits_volume_used_gb / openstack_cinder_limits_volume_max_gb > 0.9 and openstack_cinder_limits_volume_max_gb > 0'
+                severity: warning
+
   - name: CI/CD
     services:
       - name: Jenkins
@@ -4300,6 +4875,9 @@ groups:
             slug: metric-plugin
             doc_url: https://plugins.jenkins.io/prometheus/
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Jenkins node offline
                 description: "At least one Jenkins node offline: `{{$labels.instance}}` in realm {{$labels.realm}}/{{$labels.env}} ({{$labels.region}})"
                 query: "jenkins_node_offline_value > 0"
@@ -4313,15 +4891,15 @@ groups:
                 description: "Jenkins healthcheck score: {{$value}}. Healthcheck failure for `{{$labels.instance}}` in realm {{$labels.realm}}/{{$labels.env}} ({{$labels.region}})"
                 query: "jenkins_health_check_score < 1"
                 severity: critical
+              - name: Jenkins builds health score
+                description: "Healthcheck failure for `{{$labels.instance}}` in realm {{$labels.realm}}/{{$labels.env}} ({{$labels.region}})"
+                query: "default_jenkins_builds_health_score < 1"
+                severity: critical
               - name: Jenkins outdated plugins
                 description: "{{ $value }} plugins need update"
                 query: "sum(jenkins_plugins_withUpdate) by (instance) > 3"
                 severity: warning
                 for: 1d
-              - name: Jenkins builds health score
-                description: "Healthcheck failure for `{{$labels.instance}}` in realm {{$labels.realm}}/{{$labels.env}} ({{$labels.region}})"
-                query: "default_jenkins_builds_health_score < 1"
-                severity: critical
               - name: Jenkins run failure total
                 description: "Job run failures: ({{$value}}) {{$labels.jenkins_job}}. Healthcheck failure for `{{$labels.instance}}` in realm {{$labels.realm}}/{{$labels.env}} ({{$labels.region}})"
                 query: "increase(jenkins_runs_failure_total[1h]) > 100"
@@ -4349,6 +4927,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: ArgoCD service not synced
                 description: Service {{ $labels.name }} run by argo is currently not in sync.
                 query: 'argocd_app_info{sync_status!="Synced"} != 0'
@@ -4405,6 +4986,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://fluxcd.io/flux/monitoring/metrics/
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Flux Kustomization Failure
                 description: The {{ $labels.customresource_kind }} '{{ $labels.name }}' in namespace {{ $labels.exported_namespace }} is marked as not ready.
                 query: 'gotk_resource_info{ready="False", customresource_kind="Kustomization"} > 0'
@@ -4433,7 +5017,36 @@ groups:
             slug: gitlab-built-in-exporter
             doc_url: https://docs.gitlab.com/administration/monitoring/prometheus/gitlab_metrics/
             rules:
-              # Puma web server
+              #
+              # Availability
+              #
+              - name: GitLab Puma workers not running
+                description: "GitLab Puma on {{ $labels.instance }} has {{ $value }} running workers out of expected total."
+                query: "puma_running_workers < puma_workers"
+                severity: warning
+                for: 5m
+              # HTTP request handling
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: GitLab high memory usage
+                description: "GitLab process on {{ $labels.instance }} is using {{ $value | humanize1024 }}B of RSS memory."
+                query: "process_resident_memory_bytes{job=~\".*gitlab.*\"} > 2e+9"
+                severity: warning
+                for: 10m
+                comments: |
+                  Threshold of 2GB may need adjustment based on your instance size.
+                  High memory usage can lead to OOM kills and service disruptions.
+              - name: GitLab Ruby heap fragmentation
+                description: "GitLab Ruby heap fragmentation on {{ $labels.instance }} is {{ $value }}. High fragmentation wastes memory."
+                query: "ruby_gc_stat_ext_heap_fragmentation{job=~\".*gitlab.*\"} > 0.5"
+                severity: warning
+                for: 15m
+                comments: |
+                  Heap fragmentation above 50% means a significant amount of memory is wasted.
+                  A Puma worker restart may help reclaim memory.
+              # Uncaught errors
               - name: GitLab Puma high queued connections
                 description: "GitLab Puma has {{ $value }} queued connections on {{ $labels.instance }}. Requests are waiting for an available worker thread."
                 query: "puma_queued_connections > 5"
@@ -4442,17 +5055,45 @@ groups:
                 comments: |
                   Queued connections indicate Puma workers are saturated.
                   Consider increasing puma['worker_processes'] or puma['max_threads'] in gitlab.rb.
+              - name: GitLab database connection pool saturation
+                description: "GitLab database connection pool on {{ $labels.instance }} ({{ $labels.class }}) is {{ $value }}% busy."
+                query: "gitlab_database_connection_pool_busy / gitlab_database_connection_pool_size * 100 > 90 and gitlab_database_connection_pool_size > 0"
+                severity: warning
+                for: 5m
+                comments: |
+                  When the pool is near saturation, requests may block waiting for a connection.
+                  Increase db_pool_size in gitlab.rb or investigate slow queries.
+              - name: GitLab database connection pool dead connections
+                description: "GitLab database connection pool on {{ $labels.instance }} ({{ $labels.class }}) has {{ $value }} dead connections."
+                query: "gitlab_database_connection_pool_dead > 0"
+                severity: warning
+                for: 5m
+              - name: GitLab database connection pool waiting
+                description: "GitLab on {{ $labels.instance }} has {{ $value }} threads waiting for a database connection."
+                query: "gitlab_database_connection_pool_waiting > 0"
+                severity: warning
+                for: 5m
+              # CI/CD pipelines
+              - name: GitLab high file descriptor usage
+                description: "GitLab on {{ $labels.instance }} is using {{ $value }}% of available file descriptors."
+                query: 'process_open_fds{job=~".*gitlab.*"} / process_max_fds * 100 > 80 and process_max_fds > 0'
+                severity: warning
+                for: 5m
+              # Ruby threads
+              - name: GitLab Puma high thread pool utilization
+                description: GitLab Puma thread pool on {{ $labels.instance }} is {{ $value }}% utilized, indicating sustained saturation before it becomes fully blocked.
+                query: "puma_active_connections / puma_max_threads * 100 > 90 and puma_max_threads > 0"
+                severity: warning
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: GitLab Puma no available pool capacity
                 description: "GitLab Puma pool capacity on {{ $labels.instance }} has been at 0 for 5 minutes. All threads are busy."
                 query: "puma_pool_capacity == 0"
                 severity: critical
                 for: 5m
-              - name: GitLab Puma workers not running
-                description: "GitLab Puma on {{ $labels.instance }} has {{ $value }} running workers out of expected total."
-                query: "puma_running_workers < puma_workers"
-                severity: warning
-                for: 5m
-              # HTTP request handling
               - name: GitLab high HTTP error rate
                 description: "GitLab is returning more than 5% HTTP 5xx errors on {{ $labels.instance }}."
                 query: 'sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) * 100 > 5 and sum(rate(http_requests_total[5m])) > 0'
@@ -4461,6 +5102,7 @@ groups:
                 comments: |
                   Threshold is 5% of all requests returning server errors.
                   Check GitLab logs at /var/log/gitlab/ for root cause.
+              # Puma web server
               - name: GitLab high HTTP request latency
                 description: "GitLab p95 HTTP request latency on {{ $labels.instance }} is above 10 seconds."
                 query: "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 10"
@@ -4501,25 +5143,6 @@ groups:
                   This metric requires the emit_sidekiq_histogram_metrics feature flag to be enabled.
                   High queue latency means jobs are stuck waiting. Check Sidekiq concurrency and queue sizes.
               # Database connection pool
-              - name: GitLab database connection pool saturation
-                description: "GitLab database connection pool on {{ $labels.instance }} ({{ $labels.class }}) is {{ $value }}% busy."
-                query: "gitlab_database_connection_pool_busy / gitlab_database_connection_pool_size * 100 > 90 and gitlab_database_connection_pool_size > 0"
-                severity: warning
-                for: 5m
-                comments: |
-                  When the pool is near saturation, requests may block waiting for a connection.
-                  Increase db_pool_size in gitlab.rb or investigate slow queries.
-              - name: GitLab database connection pool dead connections
-                description: "GitLab database connection pool on {{ $labels.instance }} ({{ $labels.class }}) has {{ $value }} dead connections."
-                query: "gitlab_database_connection_pool_dead > 0"
-                severity: warning
-                for: 5m
-              - name: GitLab database connection pool waiting
-                description: "GitLab on {{ $labels.instance }} has {{ $value }} threads waiting for a database connection."
-                query: "gitlab_database_connection_pool_waiting > 0"
-                severity: warning
-                for: 5m
-              # CI/CD pipelines
               - name: GitLab CI pipeline creation slow
                 description: "GitLab CI pipeline creation p95 latency on {{ $labels.instance }} is above 30 seconds."
                 query: "histogram_quantile(0.95, sum(rate(gitlab_ci_pipeline_creation_duration_seconds_bucket[5m])) by (le)) > 30"
@@ -4532,31 +5155,6 @@ groups:
                 for: 10m
                 comments: |
                   This metric may not exist in all GitLab versions. Verify against your GitLab installation.
-              - name: GitLab CI runner authentication failures
-                description: "GitLab CI runners are experiencing authentication failures on {{ $labels.instance }} ({{ $value }} failures)."
-                query: "increase(gitlab_ci_runner_authentication_failure_total[5m]) > 5"
-                severity: warning
-                for: 5m
-                comments: |
-                  Frequent runner auth failures may indicate expired tokens or misconfigured runners.
-              # Ruby process health
-              - name: GitLab high memory usage
-                description: "GitLab process on {{ $labels.instance }} is using {{ $value | humanize1024 }}B of RSS memory."
-                query: "process_resident_memory_bytes{job=~\".*gitlab.*\"} > 2e+9"
-                severity: warning
-                for: 10m
-                comments: |
-                  Threshold of 2GB may need adjustment based on your instance size.
-                  High memory usage can lead to OOM kills and service disruptions.
-              - name: GitLab Ruby heap fragmentation
-                description: "GitLab Ruby heap fragmentation on {{ $labels.instance }} is {{ $value }}. High fragmentation wastes memory."
-                query: "ruby_gc_stat_ext_heap_fragmentation{job=~\".*gitlab.*\"} > 0.5"
-                severity: warning
-                for: 15m
-                comments: |
-                  Heap fragmentation above 50% means a significant amount of memory is wasted.
-                  A Puma worker restart may help reclaim memory.
-              # Uncaught errors
               - name: GitLab rack uncaught errors
                 description: "GitLab is experiencing uncaught errors in the Rack layer on {{ $labels.instance }} ({{ $value }}/s)."
                 query: "rate(rack_uncaught_errors_total[5m]) > 0.05"
@@ -4570,20 +5168,9 @@ groups:
                 comments: |
                   This may happen during a rolling deployment. If it persists, investigate incomplete upgrades.
               # File descriptors
-              - name: GitLab high file descriptor usage
-                description: "GitLab on {{ $labels.instance }} is using {{ $value }}% of available file descriptors."
-                query: 'process_open_fds{job=~".*gitlab.*"} / process_max_fds * 100 > 80 and process_max_fds > 0'
-                severity: warning
-                for: 5m
-              # Ruby threads
               - name: GitLab Ruby threads saturated
                 description: "GitLab running threads on {{ $labels.instance }} have exceeded the expected maximum ({{ $value }})."
                 query: "sum by (instance) (gitlab_ruby_threads_running_threads) > on(instance) gitlab_ruby_threads_max_expected_threads * 1.5"
-                severity: warning
-                for: 10m
-              - name: GitLab Puma high thread pool utilization
-                description: GitLab Puma thread pool on {{ $labels.instance }} is {{ $value }}% utilized, indicating sustained saturation before it becomes fully blocked.
-                query: "puma_active_connections / puma_max_threads * 100 > 90 and puma_max_threads > 0"
                 severity: warning
                 for: 10m
               - name: GitLab Sidekiq queue not draining
@@ -4592,10 +5179,25 @@ groups:
                 severity: warning
                 for: 30m
 
+              #
+              # Info, security, and config
+              #
+              - name: GitLab CI runner authentication failures
+                description: "GitLab CI runners are experiencing authentication failures on {{ $labels.instance }} ({{ $value }} failures)."
+                query: "increase(gitlab_ci_runner_authentication_failure_total[5m]) > 5"
+                severity: warning
+                for: 5m
+                comments: |
+                  Frequent runner auth failures may indicate expired tokens or misconfigured runners.
+              # Ruby process health
+
           - name: Workhorse
             slug: workhorse
             doc_url: https://docs.gitlab.com/administration/monitoring/prometheus/gitlab_metrics/#gitlab-workhorse
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: GitLab Workhorse high error rate
                 description: "GitLab Workhorse on {{ $labels.instance }} is returning more than 10% HTTP 5xx errors."
                 query: 'sum(rate(gitlab_workhorse_http_request_duration_seconds_count{code=~"5.."}[5m])) / sum(rate(gitlab_workhorse_http_request_duration_seconds_count[5m])) * 100 > 10 and sum(rate(gitlab_workhorse_http_request_duration_seconds_count[5m])) > 0'
@@ -4621,14 +5223,20 @@ groups:
             slug: gitaly
             doc_url: https://docs.gitlab.com/administration/gitaly/monitoring/
             rules:
-              - name: GitLab Gitaly high gRPC error rate
-                description: "Gitaly on {{ $labels.instance }} is returning more than 5% gRPC errors."
-                query: 'sum(rate(grpc_server_handled_total{job="gitaly",grpc_code=~"Internal|Unavailable|DeadlineExceeded|ResourceExhausted|Aborted|Unknown|DataLoss"}[5m])) / sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) * 100 > 5 and sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) > 0'
+              #
+              # Resource saturation (USE)
+              #
+              - name: GitLab Gitaly CPU throttled
+                description: "Gitaly processes on {{ $labels.instance }} are being CPU throttled by cgroups."
+                query: "rate(gitaly_cgroup_cpu_cfs_throttled_seconds_total[5m]) > 0.1"
                 severity: warning
                 for: 5m
                 comments: |
-                  Counts server-side failures only. NotFound, AlreadyExists and Cancelled are normal gRPC
-                  responses and are deliberately excluded from the error rate.
+                  Brief throttling spikes are normal. Threshold of 0.1s/s (10% of CPU time throttled) filters out transient noise.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: GitLab Gitaly resource exhausted
                 description: "Gitaly on {{ $labels.instance }} is returning ResourceExhausted errors, indicating overload ({{ $value }}%)."
                 query: 'sum(rate(grpc_server_handled_total{job="gitaly",grpc_code="ResourceExhausted"}[5m])) / sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) * 100 > 1 and sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) > 0'
@@ -4637,22 +5245,6 @@ groups:
                 comments: |
                   ResourceExhausted errors from Gitaly mean Git operations are being rejected due to
                   concurrency limits. This directly impacts users trying to push, pull, or clone.
-              - name: GitLab Gitaly high RPC latency
-                description: "Gitaly on {{ $labels.instance }} p95 unary RPC latency exceeds 1 second ({{ $value }}s)."
-                query: 'histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{job="gitaly",grpc_type="unary"}[5m])) by (le)) > 1'
-                severity: warning
-                for: 5m
-              - name: GitLab Gitaly CPU throttled
-                description: "Gitaly processes on {{ $labels.instance }} are being CPU throttled by cgroups."
-                query: "rate(gitaly_cgroup_cpu_cfs_throttled_seconds_total[5m]) > 0.1"
-                severity: warning
-                for: 5m
-                comments: |
-                  Brief throttling spikes are normal. Threshold of 0.1s/s (10% of CPU time throttled) filters out transient noise.
-              - name: GitLab Gitaly authentication failures
-                description: "Gitaly on {{ $labels.instance }} has authentication failures ({{ $value }})."
-                query: 'increase(gitaly_authentications_total{status="denied"}[5m]) > 3'
-                severity: warning
               - name: GitLab Gitaly circuit breaker tripped
                 description: "Gitaly circuit breaker has tripped on {{ $labels.instance }}. Git operations are failing."
                 query: 'increase(gitaly_circuit_breaker_transitions_total{to_state="open"}[5m]) > 0'
@@ -4660,6 +5252,27 @@ groups:
                 comments: |
                   When the circuit breaker trips to "open" state, Git operations (push, pull, clone) will fail.
                   Check Gitaly service health and logs.
+              - name: GitLab Gitaly high gRPC error rate
+                description: "Gitaly on {{ $labels.instance }} is returning more than 5% gRPC errors."
+                query: 'sum(rate(grpc_server_handled_total{job="gitaly",grpc_code=~"Internal|Unavailable|DeadlineExceeded|ResourceExhausted|Aborted|Unknown|DataLoss"}[5m])) / sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) * 100 > 5 and sum(rate(grpc_server_handled_total{job="gitaly"}[5m])) > 0'
+                severity: warning
+                for: 5m
+                comments: |
+                  Counts server-side failures only. NotFound, AlreadyExists and Cancelled are normal gRPC
+                  responses and are deliberately excluded from the error rate.
+              - name: GitLab Gitaly high RPC latency
+                description: "Gitaly on {{ $labels.instance }} p95 unary RPC latency exceeds 1 second ({{ $value }}s)."
+                query: 'histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{job="gitaly",grpc_type="unary"}[5m])) by (le)) > 1'
+                severity: warning
+                for: 5m
+
+              #
+              # Info, security, and config
+              #
+              - name: GitLab Gitaly authentication failures
+                description: "Gitaly on {{ $labels.instance }} has authentication failures ({{ $value }})."
+                query: 'increase(gitaly_authentications_total{status="denied"}[5m]) > 3'
+                severity: warning
 
       - name: Spinnaker
         logo: /images/services/spinnaker.svg
@@ -4668,6 +5281,31 @@ groups:
             slug: embedded-exporter
             doc_url: https://spinnaker.io/docs/setup/other_config/monitoring/
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Spinnaker thread pool exhaustion
+                description: "Orca message handler thread pool has {{ $value }} blocked threads on {{ $labels.instance }}. Pipeline execution throughput is degraded."
+                query: 'threadpool_blockingQueueSize > 0'
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Spinnaker dead messages
+                description: "Orca is producing dead-lettered messages ({{ $value | humanize }}/s). These are tasks that exhausted all retries and will not be executed."
+                query: 'rate(queue_dead_messages_total[5m]) > 0.05'
+                severity: critical
+                for: 2m
+              - name: Spinnaker polling monitor items over threshold
+                description: "Igor polling monitor {{ $labels.monitor }} for {{ $labels.partition }} has exceeded its item threshold, preventing pipeline triggers."
+                query: 'sum by (monitor, partition) (pollingMonitor_itemsOverThreshold) > 0'
+                severity: critical
+                for: 5m
+                comments: |
+                  When this threshold is exceeded, Igor stops triggering pipelines for the affected monitor.
+                  See https://kb.armory.io/s/article/Hitting-Igor-s-caching-thresholds
               - name: Spinnaker circuit breaker open
                 description: "Circuit breaker {{ $labels.name }} is open on {{ $labels.instance }}, indicating repeated downstream failures."
                 query: 'resilience4j_circuitbreaker_state{state="open"} == 1'
@@ -4688,11 +5326,6 @@ groups:
                 for: 5m
                 comments: |
                   The 30s threshold is a rough default. Adjust based on your pipeline SLOs.
-              - name: Spinnaker dead messages
-                description: "Orca is producing dead-lettered messages ({{ $value | humanize }}/s). These are tasks that exhausted all retries and will not be executed."
-                query: 'rate(queue_dead_messages_total[5m]) > 0.05'
-                severity: critical
-                for: 2m
               - name: Spinnaker zombie executions
                 description: "Zombie pipeline executions rate is {{ $value | humanize }}/s. These are executions with no corresponding queue messages."
                 query: 'rate(queue_zombies_total[5m]) > 0.05'
@@ -4701,19 +5334,6 @@ groups:
                 comments: |
                   Zombies are pipeline executions that are running but have lost their queue entry.
                   See https://spinnaker.io/docs/guides/runbooks/orca-zombie-executions/
-              - name: Spinnaker thread pool exhaustion
-                description: "Orca message handler thread pool has {{ $value }} blocked threads on {{ $labels.instance }}. Pipeline execution throughput is degraded."
-                query: 'threadpool_blockingQueueSize > 0'
-                severity: warning
-                for: 5m
-              - name: Spinnaker polling monitor items over threshold
-                description: "Igor polling monitor {{ $labels.monitor }} for {{ $labels.partition }} has exceeded its item threshold, preventing pipeline triggers."
-                query: 'sum by (monitor, partition) (pollingMonitor_itemsOverThreshold) > 0'
-                severity: critical
-                for: 5m
-                comments: |
-                  When this threshold is exceeded, Igor stops triggering pipelines for the affected monitor.
-                  See https://kb.armory.io/s/article/Hitting-Igor-s-caching-thresholds
               - name: Spinnaker polling monitor failures
                 description: "Igor polling monitor is experiencing failures ({{ $value }} per second). CI/SCM integrations may not trigger pipelines."
                 query: 'rate(pollingMonitor_failed_total[5m]) > 0.05'
@@ -4754,6 +5374,9 @@ groups:
             slug: nlamirault-speedtest-exporter
             doc_url: https://github.com/nlamirault/speedtest_exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: SpeedTest Slow Internet Download
                 description: Internet download speed is currently {{humanize $value}} Mbps.
                 query: "avg_over_time(speedtest_download[10m]) < 100"
@@ -4770,19 +5393,26 @@ groups:
             slug: ribbybibby-ssl-exporter
             doc_url: https://github.com/ribbybibby/ssl_exporter
             rules:
+              #
+              # Availability
+              #
               - name: SSL certificate probe failed
                 description: Failed to fetch SSL information {{ $labels.instance }}
                 query: ssl_probe_success == 0
                 severity: critical
                 for: 1m
-              - name: SSL certificate OCSP status unknown
-                description: Failed to get the OCSP status for {{ $labels.instance }}
-                query: ssl_ocsp_response_status == 2
-                severity: warning
+
+              #
+              # Info, security, and config
+              #
               - name: SSL certificate revoked
                 description: SSL certificate revoked {{ $labels.instance }}
                 query: ssl_ocsp_response_status == 1
                 severity: critical
+              - name: SSL certificate OCSP status unknown
+                description: Failed to get the OCSP status for {{ $labels.instance }}
+                query: ssl_ocsp_response_status == 2
+                severity: warning
               - name: SSL certificate expiry (< 7 days)
                 description: "{{ $labels.instance }} Certificate is expiring in 7 days"
                 query: ssl_verified_cert_not_after{chain_no="0"} - time() < 86400 * 7
@@ -4795,18 +5425,18 @@ groups:
             slug: embedded-exporter
             doc_url: https://cert-manager.io/docs/devops-tips/prometheus-metrics/
             rules:
+              #
+              # Availability
+              #
               - name: Cert-Manager absent
                 description: Cert-Manager has disappeared from Prometheus service discovery. New certificates will not be able to be minted, and existing ones can't be renewed until cert-manager is back.
                 query: 'absent(up{job="cert-manager"})'
                 severity: critical
                 for: 10m
-              - name: Cert-Manager certificate expiring soon
-                description: The certificate {{ $labels.name }} is expiring in less than 21 days.
-                query: 'avg by (exported_namespace, namespace, name) (certmanager_certificate_expiration_timestamp_seconds - time()) < (21 * 24 * 3600)'
-                severity: warning
-                for: 1h
-                comments: |
-                  Threshold of 21 days is a rough default. ACME certificates are typically renewed 30 days before expiry, so expiring within 21 days may indicate issuer misconfiguration.
+
+              #
+              # Info, security, and config
+              #
               - name: Cert-Manager certificate not ready
                 description: "The certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is not ready to serve traffic."
                 query: 'max by (name, exported_namespace, namespace, condition) (certmanager_certificate_ready_status{condition!="True"} == 1)'
@@ -4820,6 +5450,13 @@ groups:
                 comments: |
                   Metric renamed in cert-manager v1.19+ (dropped the http_ prefix): certmanager_acme_client_request_count.
                   For cert-manager < v1.19, use: certmanager_http_acme_client_request_count.
+              - name: Cert-Manager certificate expiring soon
+                description: The certificate {{ $labels.name }} is expiring in less than 21 days.
+                query: 'avg by (exported_namespace, namespace, name) (certmanager_certificate_expiration_timestamp_seconds - time()) < (21 * 24 * 3600)'
+                severity: warning
+                for: 1h
+                comments: |
+                  Threshold of 21 days is a rough default. ACME certificates are typically renewed 30 days before expiry, so expiring within 21 days may indicate issuer misconfiguration.
 
       - name: Juniper
         logo: /images/services/juniper.png
@@ -4828,10 +5465,17 @@ groups:
             slug: czerwonk-junos-exporter
             doc_url: https://github.com/czerwonk/junos_exporter
             rules:
+              #
+              # Availability
+              #
               - name: Juniper switch down
                 description: The switch appears to be down
                 query: junos_up == 0
                 severity: critical
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Juniper critical Bandwidth Usage 1GiB
                 description: Interface is highly saturated. (> 0.90GiB/s)
                 query: "rate(junos_interface_transmit_bytes[1m]) * 8 > 1e+9 * 0.90"
@@ -4849,6 +5493,18 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Availability
+              #
+              - name: CoreDNS Forward Plugin SERVFAIL Rate Critical
+                description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests forwarded to upstream {{ $labels.to }}, indicating the upstream resolver is largely unreachable or broken.
+                query: 'sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, rcode) (rate(coredns_forward_responses_total[5m])) > 0.03'
+                severity: critical
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: CoreDNS Panic Count
                 description: Number of CoreDNS panics encountered
                 query: "increase(coredns_panics_total[1m]) > 0"
@@ -4857,11 +5513,6 @@ groups:
                 description: CoreDNS 99th percentile request duration on server {{ $labels.server }} zone {{ $labels.zone }} is {{ $value }}s, indicating the resolver is overloaded or struggling to answer queries in time.
                 query: "histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) without (instance, pod)) > 4"
                 severity: critical
-                for: 10m
-              - name: CoreDNS SERVFAIL Error Rate High
-                description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of DNS responses, meaning client queries are failing to resolve.
-                query: 'sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total[5m])) > 0.01'
-                severity: warning
                 for: 10m
               - name: CoreDNS SERVFAIL Error Rate Critical
                 description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of DNS responses, meaning a large share of client queries are failing to resolve.
@@ -4873,25 +5524,25 @@ groups:
                 query: "histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket[5m])) without (pod, instance, rcode)) > 4"
                 severity: critical
                 for: 10m
+              - name: CoreDNS Forward All Upstreams Broken
+                description: CoreDNS health checks have failed for every configured upstream server, meaning forwarded DNS queries can no longer be resolved.
+                query: "sum without (pod, instance) (rate(coredns_forward_healthcheck_broken_total[5m])) > 0"
+                severity: critical
+                for: 10m
+              - name: CoreDNS SERVFAIL Error Rate High
+                description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of DNS responses, meaning client queries are failing to resolve.
+                query: 'sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total[5m])) > 0.01'
+                severity: warning
+                for: 10m
               - name: CoreDNS Forward Plugin SERVFAIL Rate High
                 description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests forwarded to upstream {{ $labels.to }}, indicating the upstream resolver is unhealthy.
                 query: 'sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, rcode) (rate(coredns_forward_responses_total[5m])) > 0.01'
                 severity: warning
                 for: 10m
-              - name: CoreDNS Forward Plugin SERVFAIL Rate Critical
-                description: CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests forwarded to upstream {{ $labels.to }}, indicating the upstream resolver is largely unreachable or broken.
-                query: 'sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, rcode) (rate(coredns_forward_responses_total[5m])) > 0.03'
-                severity: critical
-                for: 10m
               - name: CoreDNS Forward Upstream Healthcheck Failing
                 description: CoreDNS health checks are failing for upstream server {{ $labels.to }}, which may be removed from the forwarding rotation if it stays unhealthy.
                 query: "sum without (pod, instance) (rate(coredns_forward_healthcheck_failures_total[5m])) > 0"
                 severity: warning
-                for: 10m
-              - name: CoreDNS Forward All Upstreams Broken
-                description: CoreDNS health checks have failed for every configured upstream server, meaning forwarded DNS queries can no longer be resolved.
-                query: "sum without (pod, instance) (rate(coredns_forward_healthcheck_broken_total[5m])) > 0"
-                severity: critical
                 for: 10m
 
       - name: Freeswitch
@@ -4901,21 +5552,28 @@ groups:
             slug: znerol-freeswitch-exporter
             doc_url: https://pypi.org/project/prometheus-freeswitch-exporter
             rules:
+              #
+              # Availability
+              #
               - name: Freeswitch down
                 description: "Freeswitch {{ $labels.instance }} is unresponsive."
                 query: "freeswitch_up == 0"
                 severity: critical
                 for: 1m
-              - name: Freeswitch Sessions Warning
-                description: 'High sessions usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
-                query: "(freeswitch_session_active * 100 / freeswitch_session_limit) > 80 and freeswitch_session_limit > 0"
-                severity: warning
-                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Freeswitch Sessions Critical
                 description: 'High sessions usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
                 query: "(freeswitch_session_active * 100 / freeswitch_session_limit) > 90 and freeswitch_session_limit > 0"
                 severity: critical
                 for: 5m
+              - name: Freeswitch Sessions Warning
+                description: 'High sessions usage on {{ $labels.instance }}: {{ $value | printf "%.2f"}}%'
+                query: "(freeswitch_session_active * 100 / freeswitch_session_limit) > 80 and freeswitch_session_limit > 0"
+                severity: warning
+                for: 10m
 
       - name: Hashicorp Vault
         logo: /images/services/hashicorp-vault.svg
@@ -4924,16 +5582,23 @@ groups:
             slug: embedded-exporter
             doc_url: https://github.com/hashicorp/vault/blob/master/website/content/docs/configuration/telemetry.mdx#prometheus
             rules:
+              #
+              # Availability
+              #
+              - name: Vault autopilot unhealthy
+                description: Vault Autopilot reports the Raft integrated storage cluster on {{ $labels.instance }} as unhealthy, which may indicate node health, quorum, or version mismatch issues.
+                query: "min(vault_autopilot_healthy) by (instance) == 0"
+                severity: critical
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Vault sealed
                 description: "Vault instance is sealed on {{ $labels.instance }}"
                 query: "vault_core_unsealed == 0"
                 severity: critical
                 for: 1m
-              - name: Vault too many infinity tokens
-                description: "Too many non-expiring tokens on {{ $labels.instance }}: {{ $value }} tokens with infinite TTL."
-                query: 'vault_token_count_by_ttl{creation_ttl="+Inf"} > 3'
-                severity: warning
-                for: 5m
               - name: Vault cluster health
                 description: "Vault cluster has no active node — the cluster cannot serve requests."
                 query: "sum(vault_core_active) < 1"
@@ -4943,6 +5608,11 @@ groups:
               # operands would otherwise carry identical label sets and the or would discard the
               # response-failure branch entirely — and Vault increments log_request_failure on every
               # request (with 0.0 on success), so that branch is always present to mask it.
+              - name: Vault too many infinity tokens
+                description: "Too many non-expiring tokens on {{ $labels.instance }}: {{ $value }} tokens with infinite TTL."
+                query: 'vault_token_count_by_ttl{creation_ttl="+Inf"} > 3'
+                severity: warning
+                for: 5m
               - name: Vault audit log write failures
                 description: 'Vault failed to write to an audit device on {{ $labels.instance }} ({{ $value | printf "%.2f" }} failures/s), so audit log entries may be incomplete. Check audit device connectivity, disk space, or permissions.'
                 query: "sum(rate(vault_audit_log_request_failure[5m])) by (instance) > 0 or sum(rate(vault_audit_log_response_failure[5m])) by (instance) > 0"
@@ -4958,11 +5628,6 @@ groups:
                 query: "vault_raft_storage_stats_fsm_pending > 100"
                 severity: warning
                 for: 5m
-              - name: Vault autopilot unhealthy
-                description: Vault Autopilot reports the Raft integrated storage cluster on {{ $labels.instance }} as unhealthy, which may indicate node health, quorum, or version mismatch issues.
-                query: "min(vault_autopilot_healthy) by (instance) == 0"
-                severity: critical
-                for: 5m
 
       - name: Keycloak
         logo: /images/services/keycloak.svg
@@ -4971,6 +5636,15 @@ groups:
             slug: aerogear-keycloak-metrics-spi
             doc_url: https://github.com/aerogear/keycloak-metrics-spi
             rules:
+              #
+              # Performance and errors (RED)
+              #
+              - name: Keycloak no successful logins
+                description: "No successful logins in realm {{ $labels.realm }} for the last 15 minutes."
+                query: 'sum by (realm) (rate(keycloak_logins_total[15m])) == 0 and (sum by (realm) (rate(keycloak_logins_total[15m])) + sum by (realm) (rate(keycloak_failed_login_attempts_total[15m]))) > 0'
+                severity: critical
+                for: 5m
+                comments: Only fires when login attempts exist but none succeed — may indicate an authentication outage.
               - name: Keycloak high login failure rate
                 description: "More than 5% of login attempts are failing in realm {{ $labels.realm }} (current value: {{ $value | printf \"%.1f\" }}%)."
                 query: '(sum by (realm) (rate(keycloak_failed_login_attempts_total[5m])) / (sum by (realm) (rate(keycloak_logins_total[5m])) + sum by (realm) (rate(keycloak_failed_login_attempts_total[5m])))) * 100 > 5 and (sum by (realm) (rate(keycloak_logins_total[5m])) + sum by (realm) (rate(keycloak_failed_login_attempts_total[5m]))) > 0'
@@ -4979,12 +5653,6 @@ groups:
                 comments: |
                   Threshold of 5% is a rough default. Adjust based on your user base and expected error rates.
                   A spike in failed logins may indicate a brute-force attack or misconfigured client.
-              - name: Keycloak no successful logins
-                description: "No successful logins in realm {{ $labels.realm }} for the last 15 minutes."
-                query: 'sum by (realm) (rate(keycloak_logins_total[15m])) == 0 and (sum by (realm) (rate(keycloak_logins_total[15m])) + sum by (realm) (rate(keycloak_failed_login_attempts_total[15m]))) > 0'
-                severity: critical
-                for: 5m
-                comments: Only fires when login attempts exist but none succeed — may indicate an authentication outage.
               - name: Keycloak high token refresh error rate
                 description: "More than 10% of token refresh attempts are failing in realm {{ $labels.realm }} (current value: {{ $value | printf \"%.1f\" }}%)."
                 query: '(sum by (realm) (rate(keycloak_refresh_tokens_errors_total[5m])) / sum by (realm) (rate(keycloak_refresh_tokens_total[5m]))) * 100 > 10 and sum by (realm) (rate(keycloak_refresh_tokens_total[5m])) > 0'
@@ -5018,23 +5686,30 @@ groups:
             slug: lablabs-cloudflare-exporter
             doc_url: https://github.com/lablabs/cloudflare-exporter
             rules:
-              - name: Cloudflare http 4xx error rate
-                description: "Cloudflare high HTTP 4xx error rate (> 5% for domain {{ $labels.zone }})"
-                query: '(sum by(zone) (rate(cloudflare_zone_requests_status{status=~"^4.."}[15m])) / on (zone) sum by (zone) (rate(cloudflare_zone_requests_status[15m]))) * 100 > 5 and sum by (zone) (rate(cloudflare_zone_requests_status[15m])) > 0'
-                severity: warning
-              - name: Cloudflare http 5xx error rate
-                description: "Cloudflare high HTTP 5xx error rate (> 5% for domain {{ $labels.zone }})"
-                query: '(sum by (zone) (rate(cloudflare_zone_requests_status{status=~"^5.."}[5m])) / on (zone) sum by (zone) (rate(cloudflare_zone_requests_status[5m]))) * 100 > 5 and sum by (zone) (rate(cloudflare_zone_requests_status[5m])) > 0'
-                severity: critical
-              - name: Cloudflare high threat count
-                description: Cloudflare zone {{ $labels.zone }} recorded {{ $value }} threats (WAF/DDoS blocks) in the last 5 minutes, which may indicate an ongoing attack.
-                query: "sum by (zone) (increase(cloudflare_zone_threats_total[5m])) > 3"
-                severity: warning
+              #
+              # Availability
+              #
               - name: Cloudflare load balancer pool unhealthy
                 description: Cloudflare load balancer pool {{ $labels.pool_name }} for zone {{ $labels.zone }} is reporting as unhealthy, meaning origin servers behind this pool may be unreachable.
                 query: "cloudflare_zone_pool_health_status == 0"
                 severity: critical
                 for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Cloudflare http 5xx error rate
+                description: "Cloudflare high HTTP 5xx error rate (> 5% for domain {{ $labels.zone }})"
+                query: '(sum by (zone) (rate(cloudflare_zone_requests_status{status=~"^5.."}[5m])) / on (zone) sum by (zone) (rate(cloudflare_zone_requests_status[5m]))) * 100 > 5 and sum by (zone) (rate(cloudflare_zone_requests_status[5m])) > 0'
+                severity: critical
+              - name: Cloudflare http 4xx error rate
+                description: "Cloudflare high HTTP 4xx error rate (> 5% for domain {{ $labels.zone }})"
+                query: '(sum by(zone) (rate(cloudflare_zone_requests_status{status=~"^4.."}[15m])) / on (zone) sum by (zone) (rate(cloudflare_zone_requests_status[15m]))) * 100 > 5 and sum by (zone) (rate(cloudflare_zone_requests_status[15m])) > 0'
+                severity: warning
+              - name: Cloudflare high threat count
+                description: Cloudflare zone {{ $labels.zone }} recorded {{ $value }} threats (WAF/DDoS blocks) in the last 5 minutes, which may indicate an ongoing attack.
+                query: "sum by (zone) (increase(cloudflare_zone_threats_total[5m])) > 3"
+                severity: warning
               - name: Cloudflare high request rate
                 description: Cloudflare zone {{ $labels.zone }} request rate over the last 10 minutes is {{ $value }}% of the preceding 50-minute baseline, indicating an abnormal traffic spike (possible DDoS or misconfigured client).
                 query: "sum by (zone) (100 * (rate(cloudflare_zone_requests_total[10m]) / clamp_min(rate(cloudflare_zone_requests_total[50m] offset 10m), 1))) > 150"
@@ -5050,6 +5725,9 @@ groups:
               These rules use standard IF-MIB and SNMPv2-MIB metrics. Metric names depend on your snmp.yml module configuration.
               Thresholds for bandwidth and error rates are rough defaults - adjust to your environment.
             rules:
+              #
+              # Availability
+              #
               - name: SNMP target down
                 description: "SNMP device {{ $labels.instance }} is unreachable."
                 query: 'up{job=~"snmp.*"} == 0'
@@ -5062,18 +5740,10 @@ groups:
                 query: '(ifOperStatus{job=~"snmp.*"} == 2) and on(instance, job, ifIndex) (ifAdminStatus{job=~"snmp.*"} == 1)'
                 severity: critical
                 for: 2m
-              - name: SNMP interface high inbound error rate
-                description: "Interface {{ $labels.ifDescr }} on {{ $labels.instance }} has an inbound error rate above 5%."
-                query: 'rate(ifInErrors{job=~"snmp.*"}[5m]) / (rate(ifHCInUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInMulticastPkts{job=~"snmp.*"}[5m])) > 0.05 and (rate(ifHCInUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInMulticastPkts{job=~"snmp.*"}[5m])) > 0'
-                severity: warning
-                for: 5m
-                comments: Threshold is a rough default. Adjust based on your network environment.
-              - name: SNMP interface high outbound error rate
-                description: "Interface {{ $labels.ifDescr }} on {{ $labels.instance }} has an outbound error rate above 5%."
-                query: 'rate(ifOutErrors{job=~"snmp.*"}[5m]) / (rate(ifHCOutUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutMulticastPkts{job=~"snmp.*"}[5m])) > 0.05 and (rate(ifHCOutUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutMulticastPkts{job=~"snmp.*"}[5m])) > 0'
-                severity: warning
-                for: 5m
-                comments: Threshold is a rough default. Adjust based on your network environment.
+
+              #
+              # Resource saturation (USE)
+              #
               - name: SNMP interface high bandwidth usage inbound
                 description: "Interface {{ $labels.ifDescr }} on {{ $labels.instance }} inbound utilization is above 80%."
                 query: 'rate(ifHCInOctets{job=~"snmp.*"}[5m]) * 8 / ifSpeed > 0.80 and ifSpeed > 0'
@@ -5088,6 +5758,22 @@ groups:
                 for: 15m
                 comments: |
                   Threshold is a rough default. ifSpeed is a Gauge32 that maxes out at ~4.29 Gbps. For 10G+ interfaces, use ifHighSpeed (in Mbps) instead.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: SNMP interface high inbound error rate
+                description: "Interface {{ $labels.ifDescr }} on {{ $labels.instance }} has an inbound error rate above 5%."
+                query: 'rate(ifInErrors{job=~"snmp.*"}[5m]) / (rate(ifHCInUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInMulticastPkts{job=~"snmp.*"}[5m])) > 0.05 and (rate(ifHCInUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCInMulticastPkts{job=~"snmp.*"}[5m])) > 0'
+                severity: warning
+                for: 5m
+                comments: Threshold is a rough default. Adjust based on your network environment.
+              - name: SNMP interface high outbound error rate
+                description: "Interface {{ $labels.ifDescr }} on {{ $labels.instance }} has an outbound error rate above 5%."
+                query: 'rate(ifOutErrors{job=~"snmp.*"}[5m]) / (rate(ifHCOutUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutMulticastPkts{job=~"snmp.*"}[5m])) > 0.05 and (rate(ifHCOutUcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutBroadcastPkts{job=~"snmp.*"}[5m]) + rate(ifHCOutMulticastPkts{job=~"snmp.*"}[5m])) > 0'
+                severity: warning
+                for: 5m
+                comments: Threshold is a rough default. Adjust based on your network environment.
               - name: SNMP device restarted
                 description: "SNMP device {{ $labels.instance }} has restarted (uptime < 5 minutes)."
                 query: "sysUpTime / 100 < 300"
@@ -5101,7 +5787,9 @@ groups:
             slug: embedded-exporter
             doc_url: https://docs.cilium.io/en/stable/observability/metrics/
             rules:
-              # Agent health
+              #
+              # Availability
+              #
               - name: Cilium agent unreachable nodes
                 description: "Cilium agent {{ $labels.pod }} cannot reach {{ $value }} node(s). Check network connectivity and node health."
                 query: "sum(cilium_unreachable_nodes{}) by (pod) > 0"
@@ -5116,6 +5804,64 @@ groups:
                 for: 15m
                 comments: |
                   Metric name depends on Cilium version. Use cilium_unreachable_health_endpoints (older) or cilium_node_connectivity_status (1.14+).
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Cilium operator exhausted IPAM IPs
+                description: "Cilium operator has no available IPAM IPs. New pods will fail to schedule networking."
+                query: 'sum(cilium_operator_ipam_ips{type="available"}) by () <= 0'
+                severity: critical
+                for: 5m
+              - name: Cilium agent high denied rate
+                description: "Cilium agent {{ $labels.pod }} is dropping packets due to policy denial. Verify network policies are correct."
+                query: 'sum(rate(cilium_drop_count_total{reason="Policy denied"}[1m])) by (pod) > 0'
+                severity: info
+                for: 10m
+                comments: Policy denials may be expected behavior. Investigate only if unexpected traffic is being blocked.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Cilium agent conntrack table full
+                description: "Cilium agent {{ $labels.pod }} conntrack table is full, causing packet drops. Increase CT map size or investigate connection leaks."
+                query: 'sum(rate(cilium_drop_count_total{reason="CT: Map insertion failed"}[5m])) by (pod) > 0'
+                severity: critical
+                for: 5m
+              - name: Cilium agent NAT table full
+                description: "Cilium agent {{ $labels.pod }} NAT table is full, causing masquerade failures. Increase NAT map size or investigate."
+                query: 'sum(rate(cilium_drop_count_total{reason="No mapping for NAT masquerade"}[1m])) by (pod) > 0'
+                severity: critical
+                for: 5m
+              # Packet drops
+              - name: Cilium ClusterMesh remote cluster not ready
+                description: "Cilium ClusterMesh remote cluster {{ $labels.target_cluster }} is not ready from {{ $labels.source_cluster }}."
+                query: "count(cilium_clustermesh_remote_cluster_readiness_status < 1) by (source_cluster, target_cluster) > 0"
+                severity: critical
+                for: 5m
+              - name: Cilium ClusterMesh remote cluster failing
+                description: "Cilium ClusterMesh connectivity to remote cluster {{ $labels.target_cluster }} from {{ $labels.source_cluster }} is failing ({{ $value }} failures)."
+                query: "sum(rate(cilium_clustermesh_remote_cluster_failures[5m])) by (source_cluster, target_cluster) > 0"
+                severity: critical
+                for: 5m
+              # KVStoreMesh
+              - name: Cilium KVStoreMesh remote cluster not ready
+                description: "Cilium KVStoreMesh remote cluster {{ $labels.target_cluster }} is not ready from {{ $labels.source_cluster }}."
+                query: "count(cilium_kvstoremesh_remote_cluster_readiness_status < 1) by (source_cluster, target_cluster) > 0"
+                severity: critical
+                for: 5m
+              - name: Cilium KVStoreMesh remote cluster failing
+                description: "Cilium KVStoreMesh remote cluster {{ $labels.target_cluster }} from {{ $labels.source_cluster }} is experiencing failures ({{ $value }} failures)."
+                query: "sum(rate(cilium_kvstoremesh_remote_cluster_failures[5m])) by (source_cluster, target_cluster) > 0"
+                severity: critical
+                for: 5m
+              - name: Cilium KVStoreMesh sync errors
+                description: "Cilium KVStoreMesh from {{ $labels.source_cluster }} is experiencing kvstore sync errors."
+                query: "sum(rate(cilium_kvstoremesh_kvstore_sync_errors_total[5m])) by (source_cluster) > 0.05"
+                severity: critical
+                for: 5m
+              # Hubble
+              # Agent health
               - name: Cilium agent failing controllers
                 description: "Cilium agent {{ $labels.pod }} has {{ $value }} failing controller(s). Check cilium-agent logs for details."
                 query: "sum(cilium_controllers_failing{}) by (pod) > 0"
@@ -5139,12 +5885,6 @@ groups:
                 query: 'sum(rate(cilium_k8s_client_api_calls_total{method=~"(PUT|POST|PATCH)", endpoint="endpoint", return_code!~"2[0-9][0-9]"}[5m])) by (pod, method, return_code) > 0.05'
                 severity: warning
                 for: 5m
-              - name: Cilium agent endpoint create failure
-                description: "Cilium agent {{ $labels.pod }} is failing CNI endpoint-create calls. New pods may fail to get networking."
-                query: 'sum(rate(cilium_api_limiter_processed_requests_total{api_call=~"endpoint-create", outcome="fail"}[1m])) by (pod, api_call) > 0.05'
-                severity: info
-                for: 5m
-              # BPF maps
               - name: Cilium agent map operation failures
                 description: "Cilium agent {{ $labels.pod }} has eBPF map operation failures on {{ $labels.map_name }}. Datapath may be degraded."
                 query: 'sum(rate(cilium_bpf_map_ops_total{outcome="fail"}[5m])) by (map_name, pod) > 0.05'
@@ -5157,28 +5897,11 @@ groups:
                 for: 5m
                 comments: Map pressure is a ratio from 0 to 1. At 1.0, the map is full and new entries will be dropped.
               # Conntrack and NAT
-              - name: Cilium agent conntrack table full
-                description: "Cilium agent {{ $labels.pod }} conntrack table is full, causing packet drops. Increase CT map size or investigate connection leaks."
-                query: 'sum(rate(cilium_drop_count_total{reason="CT: Map insertion failed"}[5m])) by (pod) > 0'
-                severity: critical
-                for: 5m
               - name: Cilium agent conntrack failed garbage collection
                 description: "Cilium agent {{ $labels.pod }} conntrack garbage collection is failing. Stale entries may accumulate."
                 query: 'sum(rate(cilium_datapath_conntrack_gc_runs_total{status="uncompleted"}[5m])) by (pod) > 0.05'
                 severity: warning
                 for: 5m
-              - name: Cilium agent NAT table full
-                description: "Cilium agent {{ $labels.pod }} NAT table is full, causing masquerade failures. Increase NAT map size or investigate."
-                query: 'sum(rate(cilium_drop_count_total{reason="No mapping for NAT masquerade"}[1m])) by (pod) > 0'
-                severity: critical
-                for: 5m
-              # Packet drops
-              - name: Cilium agent high denied rate
-                description: "Cilium agent {{ $labels.pod }} is dropping packets due to policy denial. Verify network policies are correct."
-                query: 'sum(rate(cilium_drop_count_total{reason="Policy denied"}[1m])) by (pod) > 0'
-                severity: info
-                for: 10m
-                comments: Policy denials may be expected behavior. Investigate only if unexpected traffic is being blocked.
               - name: Cilium agent high drop rate
                 description: "Cilium agent {{ $labels.pod }} is dropping packets for reason {{ $labels.reason }}. This indicates infrastructure issues."
                 query: 'sum(rate(cilium_drop_count_total{reason!~"Policy denied"}[5m])) by (pod, reason) > 0.05'
@@ -5213,11 +5936,6 @@ groups:
                 severity: warning
                 for: 5m
               # IPAM
-              - name: Cilium operator exhausted IPAM IPs
-                description: "Cilium operator has no available IPAM IPs. New pods will fail to schedule networking."
-                query: 'sum(cilium_operator_ipam_ips{type="available"}) by () <= 0'
-                severity: critical
-                for: 5m
               - name: Cilium operator low available IPAM IPs
                 description: "Cilium operator IPAM IP pool is over 90% utilized. Allocate more IPs to avoid exhaustion."
                 query: 'sum(cilium_operator_ipam_ips{type!="available"}) by () / sum(cilium_operator_ipam_ips) by () > 0.9 and sum(cilium_operator_ipam_ips) by () > 0'
@@ -5239,39 +5957,6 @@ groups:
                 query: 'sum(rate(cilium_agent_api_process_time_seconds_count{return_code=~"5[0-9][0-9]"}[5m])) by (pod, return_code) > 0.05'
                 severity: warning
                 for: 5m
-              - name: Cilium agent Kubernetes client errors
-                description: "Cilium agent {{ $labels.pod }} is receiving errors from K8s API for endpoint {{ $labels.endpoint }} ({{ $labels.return_code }})."
-                query: 'sum(rate(cilium_k8s_client_api_calls_total{endpoint!="metrics", return_code!~"2[0-9][0-9]"}[5m])) by (pod, endpoint, return_code) > 0.05'
-                severity: info
-                for: 5m
-              # ClusterMesh
-              - name: Cilium ClusterMesh remote cluster not ready
-                description: "Cilium ClusterMesh remote cluster {{ $labels.target_cluster }} is not ready from {{ $labels.source_cluster }}."
-                query: "count(cilium_clustermesh_remote_cluster_readiness_status < 1) by (source_cluster, target_cluster) > 0"
-                severity: critical
-                for: 5m
-              - name: Cilium ClusterMesh remote cluster failing
-                description: "Cilium ClusterMesh connectivity to remote cluster {{ $labels.target_cluster }} from {{ $labels.source_cluster }} is failing ({{ $value }} failures)."
-                query: "sum(rate(cilium_clustermesh_remote_cluster_failures[5m])) by (source_cluster, target_cluster) > 0"
-                severity: critical
-                for: 5m
-              # KVStoreMesh
-              - name: Cilium KVStoreMesh remote cluster not ready
-                description: "Cilium KVStoreMesh remote cluster {{ $labels.target_cluster }} is not ready from {{ $labels.source_cluster }}."
-                query: "count(cilium_kvstoremesh_remote_cluster_readiness_status < 1) by (source_cluster, target_cluster) > 0"
-                severity: critical
-                for: 5m
-              - name: Cilium KVStoreMesh remote cluster failing
-                description: "Cilium KVStoreMesh remote cluster {{ $labels.target_cluster }} from {{ $labels.source_cluster }} is experiencing failures ({{ $value }} failures)."
-                query: "sum(rate(cilium_kvstoremesh_remote_cluster_failures[5m])) by (source_cluster, target_cluster) > 0"
-                severity: critical
-                for: 5m
-              - name: Cilium KVStoreMesh sync errors
-                description: "Cilium KVStoreMesh from {{ $labels.source_cluster }} is experiencing kvstore sync errors."
-                query: "sum(rate(cilium_kvstoremesh_kvstore_sync_errors_total[5m])) by (source_cluster) > 0.05"
-                severity: critical
-                for: 5m
-              # Hubble
               - name: Cilium Hubble lost events
                 description: "Cilium Hubble on {{ $labels.pod }} is losing flow events. Observability data may be incomplete."
                 query: "sum(rate(hubble_lost_events_total[5m])) by (pod) > 0.05"
@@ -5283,6 +5968,18 @@ groups:
                 severity: warning
                 for: 5m
                 comments: Threshold of 10% is a rough default. Some DNS errors may be normal depending on your workload.
+              - name: Cilium agent endpoint create failure
+                description: "Cilium agent {{ $labels.pod }} is failing CNI endpoint-create calls. New pods may fail to get networking."
+                query: 'sum(rate(cilium_api_limiter_processed_requests_total{api_call=~"endpoint-create", outcome="fail"}[1m])) by (pod, api_call) > 0.05'
+                severity: info
+                for: 5m
+              # BPF maps
+              - name: Cilium agent Kubernetes client errors
+                description: "Cilium agent {{ $labels.pod }} is receiving errors from K8s API for endpoint {{ $labels.endpoint }} ({{ $labels.return_code }})."
+                query: 'sum(rate(cilium_k8s_client_api_calls_total{endpoint!="metrics", return_code!~"2[0-9][0-9]"}[5m])) by (pod, endpoint, return_code) > 0.05'
+                severity: info
+                for: 5m
+              # ClusterMesh
 
       - name: WireGuard
         logo: /images/services/wireguard.svg
@@ -5291,6 +5988,16 @@ groups:
             slug: mindflavor-prometheus-wireguard-exporter
             doc_url: https://github.com/MindFlavor/prometheus_wireguard_exporter
             rules:
+              #
+              # Availability
+              #
+              - name: WireGuard peer handshake never established
+                description: "WireGuard peer {{ $labels.public_key }} on interface {{ $labels.interface }} has never completed a handshake. Check peer configuration and network connectivity."
+                query: 'wireguard_latest_handshake_seconds == 0'
+                severity: critical
+                for: 5m
+                comments: |
+                  This alert will fire for all offline mobile/laptop peers. Consider filtering by expected-online peers.
               - name: WireGuard peer handshake too old
                 description: "WireGuard peer {{ $labels.public_key }} on interface {{ $labels.interface }} has not had a handshake for over 5 minutes. The tunnel may be down."
                 query: 'time() - wireguard_latest_handshake_seconds > 300 and wireguard_latest_handshake_seconds > 0'
@@ -5300,13 +6007,10 @@ groups:
                   The threshold of 300 seconds (5 minutes) is a rough default. WireGuard peers that are idle but reachable
                   typically re-handshake every 2 minutes. Adjust based on your keepalive interval.
                   The `> 0` guard excludes peers that have never completed a handshake (covered by a separate rule).
-              - name: WireGuard peer handshake never established
-                description: "WireGuard peer {{ $labels.public_key }} on interface {{ $labels.interface }} has never completed a handshake. Check peer configuration and network connectivity."
-                query: 'wireguard_latest_handshake_seconds == 0'
-                severity: critical
-                for: 5m
-                comments: |
-                  This alert will fire for all offline mobile/laptop peers. Consider filtering by expected-online peers.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: WireGuard no traffic on peer
                 description: "WireGuard peer {{ $labels.public_key }} on interface {{ $labels.interface }} has had no traffic for 15 minutes despite an active handshake."
                 query: '(rate(wireguard_sent_bytes_total[15m]) + rate(wireguard_received_bytes_total[15m])) == 0 and wireguard_latest_handshake_seconds > 0 and (time() - wireguard_latest_handshake_seconds) < 300'
@@ -5326,42 +6030,41 @@ groups:
             slug: embedded-exporter
             doc_url: https://docs.ceph.com/en/quincy/mgr/prometheus/
             rules:
-              - name: Ceph health error
-                description: Ceph cluster is in HEALTH_ERR state
-                query: "ceph_health_status == 2"
+              #
+              # Availability
+              #
+              - name: Ceph OSD down (>= 10%)
+                description: "{{ $value | humanize }}% of OSDs are down on the cluster, exceeding the safe threshold and putting data availability at risk."
+                query: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
+                severity: critical
+              - name: Ceph PG down
+                description: Some Ceph placement groups are down. Please ensure that all the data are available.
+                query: "ceph_pg_down > 0"
+                severity: critical
+              - name: Ceph monitor quorum at risk
+                description: Ceph monitor quorum is at the minimum required to stay operational; losing one more monitor will make the cluster inoperable for all clients.
+                query: '(ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right() (count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)) == 1'
                 severity: critical
                 for: 1m
-              - name: Ceph health warning
-                description: Ceph cluster is in HEALTH_WARN state
-                query: "ceph_health_status == 1"
-                severity: warning
-                for: 1m
-              - name: Ceph monitor clock skew
-                description: Ceph monitor clock skew detected. Please check ntp and hardware clock settings
-                query: 'ceph_health_detail{name="MON_CLOCK_SKEW"} == 1'
-                severity: warning
-                for: 2m
-              - name: Ceph monitor low space
-                description: Ceph monitor storage is low.
-                query: 'ceph_health_detail{name="MON_DISK_LOW"} == 1'
-                severity: warning
-                for: 2m
               - name: Ceph OSD Down
                 description: Ceph Object Storage Daemon Down
                 query: "ceph_osd_up == 0"
                 severity: warning
                 for: 5m
-              - name: Ceph OSD down (>= 10%)
-                description: "{{ $value | humanize }}% of OSDs are down on the cluster, exceeding the safe threshold and putting data availability at risk."
-                query: "count(ceph_osd_up == 0) / count(ceph_osd_up) * 100 >= 10"
-                severity: critical
-              - name: Ceph high OSD latency
-                description: "Ceph Object Storage Daemon latency is high. Please check if it doesn't stuck in weird state."
-                query: "ceph_osd_apply_latency_ms > 5000"
+              - name: Ceph monitor down
+                description: One or more Ceph monitors are down while quorum is still intact; losing an additional monitor would make the cluster inoperable.
+                query: "count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2 + 1))"
                 severity: warning
-                for: 1m
-                comments: |
-                  Threshold of 5000ms (5 seconds). Adjust based on your expected OSD performance.
+                for: 2m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Ceph monitor low space
+                description: Ceph monitor storage is low.
+                query: 'ceph_health_detail{name="MON_DISK_LOW"} == 1'
+                severity: warning
+                for: 2m
               - name: Ceph OSD near full
                 description: A Ceph OSD is dangerously full. Please add more disks.
                 query: 'ceph_health_detail{name="OSD_NEARFULL"} == 1'
@@ -5375,14 +6078,61 @@ groups:
                 query: "ceph_osd_weight < 1"
                 severity: warning
                 for: 2m
-              - name: Ceph PG down
-                description: Some Ceph placement groups are down. Please ensure that all the data are available.
-                query: "ceph_pg_down > 0"
+              - name: Ceph PG backfill full
+                description: Some Ceph placement groups are located on full Object Storage Daemon on cluster. Those PGs can be unavailable shortly. Please check OSDs, change weight or reconfigure CRUSH rules.
+                query: "ceph_pg_backfill_toofull > 0"
+                severity: warning
+                for: 2m
+              - name: Ceph monitor clock skew
+                description: Ceph monitor clock skew detected. Please check ntp and hardware clock settings
+                query: 'ceph_health_detail{name="MON_CLOCK_SKEW"} == 1'
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Ceph health error
+                description: Ceph cluster is in HEALTH_ERR state
+                query: "ceph_health_status == 2"
                 severity: critical
+                for: 1m
               - name: Ceph PG incomplete
                 description: Some Ceph placement groups are incomplete. Please ensure that all the data are available.
                 query: "ceph_pg_incomplete > 0"
                 severity: critical
+              - name: Ceph PG unavailable
+                description: Some Ceph placement groups are unavailable.
+                query: "ceph_pg_total - ceph_pg_active > 0"
+                severity: critical
+                for: 1m
+              - name: Ceph OSD full
+                description: One or more Ceph OSDs have reached the full ratio; writes to the affected pools are blocked until space is freed or OSDs are added.
+                query: 'ceph_health_detail{name="OSD_FULL"} == 1'
+                severity: critical
+                for: 1m
+              - name: Ceph daemon crash detected
+                description: One or more Ceph daemons (OSD, mon, mgr, mds...) have crashed recently and the crash has not been acknowledged. Investigate and archive with 'ceph crash archive <id>'.
+                query: 'ceph_health_detail{name="RECENT_CRASH"} == 1'
+                severity: critical
+                for: 1m
+              - name: Ceph MDS unhealthy
+                description: The CephFS filesystem is damaged, fully offline, degraded, has a failed MDS rank with no standby, or has switched to read-only mode. Data may be partially or fully inaccessible; check 'ceph fs status' for details.
+                query: 'ceph_health_detail{name=~"MDS_DAMAGE|MDS_ALL_DOWN|FS_DEGRADED|FS_WITH_FAILED_MDS|MDS_HEALTH_READ_ONLY"} == 1'
+                severity: critical
+                for: 1m
+              - name: Ceph health warning
+                description: Ceph cluster is in HEALTH_WARN state
+                query: "ceph_health_status == 1"
+                severity: warning
+                for: 1m
+              - name: Ceph high OSD latency
+                description: "Ceph Object Storage Daemon latency is high. Please check if it doesn't stuck in weird state."
+                query: "ceph_osd_apply_latency_ms > 5000"
+                severity: warning
+                for: 1m
+                comments: |
+                  Threshold of 5000ms (5 seconds). Adjust based on your expected OSD performance.
               - name: Ceph PG inconsistent
                 description: Some Ceph placement groups are inconsistent. Data is available but inconsistent across nodes.
                 query: ceph_pg_inconsistent > 0
@@ -5392,36 +6142,6 @@ groups:
                 query: "ceph_pg_activating > 0"
                 severity: warning
                 for: 2m
-              - name: Ceph PG backfill full
-                description: Some Ceph placement groups are located on full Object Storage Daemon on cluster. Those PGs can be unavailable shortly. Please check OSDs, change weight or reconfigure CRUSH rules.
-                query: "ceph_pg_backfill_toofull > 0"
-                severity: warning
-                for: 2m
-              - name: Ceph PG unavailable
-                description: Some Ceph placement groups are unavailable.
-                query: "ceph_pg_total - ceph_pg_active > 0"
-                severity: critical
-                for: 1m
-              - name: Ceph monitor quorum at risk
-                description: Ceph monitor quorum is at the minimum required to stay operational; losing one more monitor will make the cluster inoperable for all clients.
-                query: '(ceph_health_detail{name="MON_DOWN"} == 1) * on() group_right() (count(ceph_mon_quorum_status == 1) == bool (floor(count(ceph_mon_metadata) / 2) + 1)) == 1'
-                severity: critical
-                for: 1m
-              - name: Ceph monitor down
-                description: One or more Ceph monitors are down while quorum is still intact; losing an additional monitor would make the cluster inoperable.
-                query: "count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2 + 1))"
-                severity: warning
-                for: 2m
-              - name: Ceph OSD full
-                description: One or more Ceph OSDs have reached the full ratio; writes to the affected pools are blocked until space is freed or OSDs are added.
-                query: 'ceph_health_detail{name="OSD_FULL"} == 1'
-                severity: critical
-                for: 1m
-              - name: Ceph pool full
-                description: A Ceph pool has reached its quota, or the OSDs backing it have reached the full threshold; writes to the pool are blocked until quota is increased or capacity is added.
-                query: 'ceph_health_detail{name="POOL_FULL"} == 1'
-                severity: critical
-                for: 1m
               - name: Ceph pool near full
                 description: A Ceph pool has exceeded its near-full threshold. Writes may still succeed, but the pool risks going read-only if more capacity isn't made available soon.
                 query: 'ceph_health_detail{name="POOL_NEAR_FULL"} == 1'
@@ -5442,20 +6162,19 @@ groups:
                 query: 'ceph_health_detail{name="PG_NOT_DEEP_SCRUBBED"} == 1'
                 severity: warning
                 for: 5m
-              - name: Ceph daemon crash detected
-                description: One or more Ceph daemons (OSD, mon, mgr, mds...) have crashed recently and the crash has not been acknowledged. Investigate and archive with 'ceph crash archive <id>'.
-                query: 'ceph_health_detail{name="RECENT_CRASH"} == 1'
-                severity: critical
-                for: 1m
-              - name: Ceph MDS unhealthy
-                description: The CephFS filesystem is damaged, fully offline, degraded, has a failed MDS rank with no standby, or has switched to read-only mode. Data may be partially or fully inaccessible; check 'ceph fs status' for details.
-                query: 'ceph_health_detail{name=~"MDS_DAMAGE|MDS_ALL_DOWN|FS_DEGRADED|FS_WITH_FAILED_MDS|MDS_HEALTH_READ_ONLY"} == 1'
-                severity: critical
-                for: 1m
               - name: Ceph slow ops
                 description: "{{ $value }} OSD/mon requests are taking longer than the configured complaint time to complete, an early symptom of client-facing latency and cluster degradation."
                 query: "ceph_healthcheck_slow_ops > 0"
                 severity: warning
+                for: 1m
+
+              #
+              # Capacity and trend
+              #
+              - name: Ceph pool full
+                description: A Ceph pool has reached its quota, or the OSDs backing it have reached the full threshold; writes to the pool are blocked until quota is increased or capacity is added.
+                query: 'ceph_health_detail{name="POOL_FULL"} == 1'
+                severity: critical
                 for: 1m
 
       - name: ZFS
@@ -5465,6 +6184,9 @@ groups:
             slug: node-exporter
             doc_url: https://github.com/prometheus/node_exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: ZFS offline pool
                 description: "A ZFS zpool is in a unexpected state: {{ $labels.state }}."
                 query: 'node_zfs_zpool_state{state!="online"} > 0'
@@ -5474,10 +6196,9 @@ groups:
             slug: zfs_exporter
             doc_url: https://github.com/pdf/zfs_exporter
             rules:
-              - name: ZFS pool out of space
-                description: "ZFS pool {{ $labels.pool }} is almost full (< 10% left)."
-                query: "zfs_pool_free_bytes * 100 / zfs_pool_size_bytes < 10 and zfs_pool_readonly == 0 and zfs_pool_size_bytes > 0"
-                severity: warning
+              #
+              # Performance and errors (RED)
+              #
               - name: ZFS pool unhealthy
                 description: ZFS pool state is {{ $value }}. See comments for more information.
                 query: "zfs_pool_health > 0"
@@ -5490,6 +6211,10 @@ groups:
                   4: UNAVAIL
                   5: REMOVED
                   6: SUSPENDED
+              - name: ZFS pool out of space
+                description: "ZFS pool {{ $labels.pool }} is almost full (< 10% left)."
+                query: "zfs_pool_free_bytes * 100 / zfs_pool_size_bytes < 10 and zfs_pool_readonly == 0 and zfs_pool_size_bytes > 0"
+                severity: warning
               - name: ZFS collector failed
                 description: ZFS collector for {{ $labels.instance }} has failed to collect information
                 query: "zfs_scrape_collector_success != 1"
@@ -5501,6 +6226,17 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Availability
+              #
+              - name: OpenEBS LVM volume group missing physical volume
+                description: OpenEBS LVM LocalPV volume group {{ $labels.instance }} is missing {{ $value }} underlying physical volume(s), which puts data at risk of loss.
+                query: "lvm_vg_missing_pv_count > 0"
+                severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: OpenEBS used pool capacity
                 description: "OpenEBS Pool use more than 80% of his capacity"
                 query: "openebs_used_pool_capacity_percent > 80"
@@ -5516,10 +6252,6 @@ groups:
                 query: 'lvm_lv_used_percent{segtype="thin-pool"} > 90'
                 severity: warning
                 for: 2m
-              - name: OpenEBS LVM volume group missing physical volume
-                description: OpenEBS LVM LocalPV volume group {{ $labels.instance }} is missing {{ $value }} underlying physical volume(s), which puts data at risk of loss.
-                query: "lvm_vg_missing_pv_count > 0"
-                severity: critical
 
       - name: Minio
         logo: /images/services/minio.svg
@@ -5527,6 +6259,17 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Availability
+              #
+              - name: Minio cluster erasure set quorum lost
+                description: Minio erasure set has lost quorum, meaning MinIO can no longer guarantee reads or writes for objects in this pool/set until enough drives are restored.
+                query: "minio_cluster_health_erasure_set_status < 1"
+                severity: critical
+
+              #
+              # Resource saturation (USE)
+              #
               - name: Minio cluster disk offline
                 description: "Minio cluster disk is offline"
                 query: "minio_cluster_drive_offline_total > 0"
@@ -5543,10 +6286,10 @@ groups:
                   Uses usable capacity (post erasure-coding) rather than raw capacity, so the percentage
                   reflects how much data can actually still be stored, not the physical disk bytes
                   reserved for parity.
-              - name: Minio cluster erasure set quorum lost
-                description: Minio erasure set has lost quorum, meaning MinIO can no longer guarantee reads or writes for objects in this pool/set until enough drives are restored.
-                query: "minio_cluster_health_erasure_set_status < 1"
-                severity: critical
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Minio KMS unavailable
                 description: Minio KMS backend is offline; encryption and decryption of SSE-KMS objects will fail until KMS connectivity is restored.
                 query: "minio_cluster_kms_online == 0"
@@ -5568,6 +6311,53 @@ groups:
               delay_seconds, default 600s/10m), not the scrape time — the AWS service alerts below use
               "offset 10m" to account for this. Adjust the offset if you changed delay_seconds.
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: AWS EC2 high CPU utilization
+                description: "EC2 instance {{ $labels.instance_id }} CPU utilization is above 90% ({{ $value }}%)."
+                query: "aws_ec2_cpuutilization_average offset 10m > 90"
+                severity: warning
+                for: 15m
+                comments: Requires EC2 CPUUtilization metric configured in the CloudWatch exporter.
+              - name: AWS RDS high CPU utilization
+                description: "RDS instance {{ $labels.dbinstance_identifier }} CPU utilization is above 90% ({{ $value }}%)."
+                query: "aws_rds_cpuutilization_average offset 10m > 90"
+                severity: warning
+                for: 15m
+                comments: Requires RDS CPUUtilization metric configured in the CloudWatch exporter.
+              - name: AWS RDS low free storage space
+                description: "RDS instance {{ $labels.dbinstance_identifier }} has less than 2GB free storage ({{ $value }} bytes remaining)."
+                query: "aws_rds_free_storage_space_average offset 10m < 2000000000"
+                severity: warning
+                for: 5m
+                comments: |
+                  Requires RDS FreeStorageSpace metric. The threshold of 2GB is a rough default.
+                  Adjust based on your database size.
+              - name: AWS RDS high database connections
+                description: "RDS instance {{ $labels.dbinstance_identifier }} has {{ $value }} active connections."
+                query: "aws_rds_database_connections_average offset 10m > 100"
+                severity: warning
+                for: 5m
+                comments: |
+                  The threshold depends on the RDS instance class. Adjust based on your
+                  instance type's max_connections parameter.
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: AWS ALB unhealthy targets
+                description: "ALB {{ $labels.load_balancer }} has {{ $value }} unhealthy target(s) in target group {{ $labels.target_group }}."
+                query: "aws_applicationelb_unhealthy_host_count_average offset 10m > 0"
+                severity: critical
+                for: 5m
+                comments: Requires ApplicationELB UnHealthyHostCount metric.
+              - name: AWS ALB high 5xx error rate
+                description: "ALB {{ $labels.load_balancer }} 5xx error rate is above 5% ({{ $value }}%)."
+                query: "(aws_applicationelb_httpcode_elb_5_xx_count_sum offset 10m / aws_applicationelb_request_count_sum offset 10m) * 100 > 5 and aws_applicationelb_request_count_sum offset 10m > 0"
+                severity: critical
+                for: 5m
+                comments: Requires ApplicationELB HTTPCode_ELB_5XX_Count and RequestCount metrics.
               - name: CloudWatch exporter scrape error
                 description: "CloudWatch exporter on {{ $labels.instance }} failed to scrape metrics from AWS CloudWatch API."
                 query: "cloudwatch_exporter_scrape_error > 0"
@@ -5585,34 +6375,6 @@ groups:
                 comments: |
                   CloudWatch API calls cost money (~$0.01 per 1000 GetMetricData requests).
                   100 requests/minute ≈ $45/month. Adjust the threshold based on your budget.
-              - name: AWS EC2 high CPU utilization
-                description: "EC2 instance {{ $labels.instance_id }} CPU utilization is above 90% ({{ $value }}%)."
-                query: "aws_ec2_cpuutilization_average offset 10m > 90"
-                severity: warning
-                for: 15m
-                comments: Requires EC2 CPUUtilization metric configured in the CloudWatch exporter.
-              - name: AWS RDS low free storage space
-                description: "RDS instance {{ $labels.dbinstance_identifier }} has less than 2GB free storage ({{ $value }} bytes remaining)."
-                query: "aws_rds_free_storage_space_average offset 10m < 2000000000"
-                severity: warning
-                for: 5m
-                comments: |
-                  Requires RDS FreeStorageSpace metric. The threshold of 2GB is a rough default.
-                  Adjust based on your database size.
-              - name: AWS RDS high CPU utilization
-                description: "RDS instance {{ $labels.dbinstance_identifier }} CPU utilization is above 90% ({{ $value }}%)."
-                query: "aws_rds_cpuutilization_average offset 10m > 90"
-                severity: warning
-                for: 15m
-                comments: Requires RDS CPUUtilization metric configured in the CloudWatch exporter.
-              - name: AWS RDS high database connections
-                description: "RDS instance {{ $labels.dbinstance_identifier }} has {{ $value }} active connections."
-                query: "aws_rds_database_connections_average offset 10m > 100"
-                severity: warning
-                for: 5m
-                comments: |
-                  The threshold depends on the RDS instance class. Adjust based on your
-                  instance type's max_connections parameter.
               - name: AWS SQS queue messages visible
                 description: "SQS queue {{ $labels.queue_name }} has {{ $value }} messages waiting to be processed."
                 query: "aws_sqs_approximate_number_of_messages_visible_average offset 10m > 1000"
@@ -5626,18 +6388,6 @@ groups:
                 query: "aws_sqs_approximate_age_of_oldest_message_maximum offset 10m > 3600"
                 severity: warning
                 comments: Requires SQS ApproximateAgeOfOldestMessage metric.
-              - name: AWS ALB unhealthy targets
-                description: "ALB {{ $labels.load_balancer }} has {{ $value }} unhealthy target(s) in target group {{ $labels.target_group }}."
-                query: "aws_applicationelb_unhealthy_host_count_average offset 10m > 0"
-                severity: critical
-                for: 5m
-                comments: Requires ApplicationELB UnHealthyHostCount metric.
-              - name: AWS ALB high 5xx error rate
-                description: "ALB {{ $labels.load_balancer }} 5xx error rate is above 5% ({{ $value }}%)."
-                query: "(aws_applicationelb_httpcode_elb_5_xx_count_sum offset 10m / aws_applicationelb_request_count_sum offset 10m) * 100 > 5 and aws_applicationelb_request_count_sum offset 10m > 0"
-                severity: critical
-                for: 5m
-                comments: Requires ApplicationELB HTTPCode_ELB_5XX_Count and RequestCount metrics.
               - name: AWS ALB high target response time
                 description: "ALB {{ $labels.load_balancer }} average target response time is above 2 seconds ({{ $value }}s)."
                 query: "aws_applicationelb_target_response_time_average offset 10m > 2"
@@ -5661,6 +6411,9 @@ groups:
               Self-monitoring metrics use the stackdriver_monitoring_* prefix.
               All self-monitoring metrics include a project_id label.
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Stackdriver exporter scrape error
                 description: "Stackdriver exporter failed to scrape metrics from Google Cloud Monitoring API for project {{ $labels.project_id }}."
                 query: "stackdriver_monitoring_last_scrape_error > 0"
@@ -5675,13 +6428,17 @@ groups:
                 description: "Stackdriver exporter has had {{ $value }} scrape errors in the last 15 minutes for project {{ $labels.project_id }}."
                 query: "increase(stackdriver_monitoring_scrape_errors_total[15m]) > 5"
                 severity: warning
-              - name: Stackdriver exporter high API calls
-                description: "Stackdriver exporter is making {{ $value }} API calls per minute for project {{ $labels.project_id }}. This may hit Google Cloud Monitoring API quotas."
-                query: "rate(stackdriver_monitoring_api_calls_total[5m]) * 60 > 100"
-                severity: warning
               - name: Stackdriver exporter scrape stale
                 description: "Stackdriver exporter has not successfully scraped metrics for project {{ $labels.project_id }} in the last 10 minutes."
                 query: "time() - stackdriver_monitoring_last_scrape_timestamp > 600"
+                severity: warning
+
+              #
+              # Capacity and trend
+              #
+              - name: Stackdriver exporter high API calls
+                description: "Stackdriver exporter is making {{ $value }} API calls per minute for project {{ $labels.project_id }}. This may hit Google Cloud Monitoring API quotas."
+                query: "rate(stackdriver_monitoring_api_calls_total[5m]) * 60 > 100"
                 severity: warning
 
       - name: DigitalOcean
@@ -5691,14 +6448,12 @@ groups:
             slug: digitalocean-exporter
             doc_url: https://github.com/metalmatze/digitalocean_exporter
             rules:
+              #
+              # Availability
+              #
               - name: DigitalOcean droplet down
                 description: "DigitalOcean droplet {{ $labels.name }} ({{ $labels.id }}) in {{ $labels.region }} is not running."
                 query: "digitalocean_droplet_up == 0"
-                severity: critical
-                for: 5m
-              - name: DigitalOcean account not active
-                description: "DigitalOcean account is not active. It may be suspended or locked."
-                query: "digitalocean_account_active != 1"
                 severity: critical
                 for: 5m
               - name: DigitalOcean database down
@@ -5716,6 +6471,15 @@ groups:
                 query: "digitalocean_loadbalancer_status == 0"
                 severity: critical
                 for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: DigitalOcean account not active
+                description: "DigitalOcean account is not active. It may be suspended or locked."
+                query: "digitalocean_account_active != 1"
+                severity: critical
+                for: 5m
               - name: DigitalOcean load balancer no backends
                 description: "DigitalOcean load balancer {{ $labels.name }} ({{ $labels.ip }}) has no droplets attached."
                 query: "digitalocean_loadbalancer_droplets == 0"
@@ -5735,6 +6499,10 @@ groups:
                 query: "increase(digitalocean_errors_total[5m]) > 3"
                 severity: warning
                 for: 5m
+
+              #
+              # Capacity and trend
+              #
               - name: DigitalOcean droplet limit approaching
                 description: "DigitalOcean account is using {{ $value }}% of its droplet quota."
                 query: "(count(digitalocean_droplet_up) / digitalocean_account_droplet_limit) * 100 > 80 and digitalocean_account_droplet_limit > 0"
@@ -5757,6 +6525,9 @@ groups:
               The metric name can be customized via the name parameter in probe configuration.
               Self-monitoring metrics use the azurerm_stats_* and azurerm_api_* prefixes.
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Azure API read rate limit approaching
                 description: "Azure API read rate limit for subscription {{ $labels.subscriptionID }} is running low ({{ $value }} remaining)."
                 query: 'azurerm_api_ratelimit{type="reads"} < 100'
@@ -5784,6 +6555,9 @@ groups:
           - name: Thanos Compactor
             slug: thanos-compactor
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Compactor Multiple Running
                 description: "No more than one Thanos Compact instance should be running at once. There are {{$value}} instances running."
                 query: 'sum by (job) (up{job=~".*thanos-compact.*"}) > 1'
@@ -5812,6 +6586,9 @@ groups:
           - name: Thanos Query
             slug: thanos-query
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Query Http Request Query Error Rate High
                 description: 'Thanos Query {{$labels.job}} is failing to handle {{$value | humanize}}% of "query" requests.'
                 query: '(sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query"}[5m]))/  sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query"}[5m]))) * 100 > 5 and sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query"}[5m])) > 0'
@@ -5822,6 +6599,16 @@ groups:
                 query: '(sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-query.*", handler="query_range"}[5m]))/  sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query_range"}[5m]))) * 100 > 5 and sum by (job) (rate(http_requests_total{job=~".*thanos-query.*", handler="query_range"}[5m])) > 0'
                 severity: critical
                 for: 5m
+              - name: Thanos Query Instant Latency High
+                description: "Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}} seconds for instant queries."
+                query: '(histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m]))) > 40 and sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query"}[5m])) > 0)'
+                severity: critical
+                for: 10m
+              - name: Thanos Query Range Latency High
+                description: "Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}} seconds for range queries."
+                query: '(histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query_range"}[5m]))) > 90 and sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query_range"}[5m])) > 0)'
+                severity: critical
+                for: 10m
               - name: Thanos Query Grpc Server Error Rate
                 description: "Thanos Query {{$labels.job}} is failing to handle {{$value | humanize}}% of requests."
                 query: '(sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-query.*"}[5m]))/  sum by (job) (rate(grpc_server_started_total{job=~".*thanos-query.*"}[5m])) * 100 > 5) and sum by (job) (rate(grpc_server_started_total{job=~".*thanos-query.*"}[5m])) > 0'
@@ -5840,16 +6627,6 @@ groups:
                 query: '(sum by (job) (rate(thanos_query_store_apis_dns_failures_total[5m])) / sum by (job) (rate(thanos_query_store_apis_dns_lookups_total[5m]))) * 100 > 1 and sum by (job) (rate(thanos_query_store_apis_dns_lookups_total[5m])) > 0'
                 severity: warning
                 for: 15m
-              - name: Thanos Query Instant Latency High
-                description: "Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}} seconds for instant queries."
-                query: '(histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query"}[5m]))) > 40 and sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query"}[5m])) > 0)'
-                severity: critical
-                for: 10m
-              - name: Thanos Query Range Latency High
-                description: "Thanos Query {{$labels.job}} has a 99th percentile latency of {{$value}} seconds for range queries."
-                query: '(histogram_quantile(0.99, sum by (job, le) (rate(http_request_duration_seconds_bucket{job=~".*thanos-query.*", handler="query_range"}[5m]))) > 90 and sum by (job) (rate(http_request_duration_seconds_count{job=~".*thanos-query.*", handler="query_range"}[5m])) > 0)'
-                severity: critical
-                for: 10m
               - name: Thanos Query Overload
                 description: "Thanos Query {{$labels.job}} has been overloaded for more than 15 minutes. This may be a symptom of excessive simultanous complex requests, low performance of the Prometheus API, or failures within these components. Assess the health of the Thanos query instances, the connnected Prometheus instances, look for potential senders of these requests and then contact support."
                 query: "(max_over_time(thanos_query_concurrent_gate_queries_max[5m]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight[5m]) < 1)"
@@ -5858,6 +6635,18 @@ groups:
           - name: Thanos Receiver
             slug: thanos-receiver
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Thanos Receive No Upload
+                description: "Thanos Receive {{$labels.instance}} has not uploaded latest data to object storage."
+                query: '(up{job=~".*thanos-receive.*"} - 1) + on (job, instance) (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~".*thanos-receive.*"}[3h])) == 0)'
+                severity: critical
+                for: 3h
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Receive Http Request Error Rate High
                 description: "Thanos Receive {{$labels.job}} is failing to handle {{$value | humanize}}% of requests."
                 query: '(sum by (job) (rate(http_requests_total{code=~"5..", job=~".*thanos-receive.*", handler="receive"}[5m]))/  sum by (job) (rate(http_requests_total{job=~".*thanos-receive.*", handler="receive"}[5m]))) * 100 > 5 and sum by (job) (rate(http_requests_total{job=~".*thanos-receive.*", handler="receive"}[5m])) > 0'
@@ -5873,31 +6662,11 @@ groups:
                 query: 'thanos_receive_replication_factor > 1 and ((sum by (job) (rate(thanos_receive_replications_total{result="error"}[5m])) / sum by (job) (rate(thanos_receive_replications_total[5m]))) > (max by (job) (floor((thanos_receive_replication_factor+1)/ 2)) / max by (job) (thanos_receive_hashring_nodes))) * 100'
                 severity: warning
                 for: 5m
-              - name: Thanos Receive High Forward Request Failures
-                description: "Thanos Receive {{$labels.job}} is failing to forward {{$value | humanize}}% of requests."
-                query: '(sum by (job) (rate(thanos_receive_forward_requests_total{result="error"}[5m]))/  sum by (job) (rate(thanos_receive_forward_requests_total[5m]))) * 100 > 20 and sum by (job) (rate(thanos_receive_forward_requests_total[5m])) > 0'
-                severity: info
-                for: 5m
               - name: Thanos Receive High Hashring File Refresh Failures
                 description: "Thanos Receive {{$labels.job}} is failing to refresh hashring file, {{$value | humanize}} of attempts failed."
                 query: '(sum by (job) (rate(thanos_receive_hashrings_file_errors_total[5m])) / sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total[5m])) > 0) and sum by (job) (rate(thanos_receive_hashrings_file_refreshes_total[5m])) > 0'
                 severity: warning
                 for: 15m
-              - name: Thanos Receive Config Reload Failure
-                description: "Thanos Receive {{$labels.job}} has not been able to reload hashring configurations."
-                query: 'avg by (job) (thanos_receive_config_last_reload_successful) != 1'
-                severity: warning
-                for: 5m
-              - name: Thanos Receive No Upload
-                description: "Thanos Receive {{$labels.instance}} has not uploaded latest data to object storage."
-                query: '(up{job=~".*thanos-receive.*"} - 1) + on (job, instance) (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~".*thanos-receive.*"}[3h])) == 0)'
-                severity: critical
-                for: 3h
-              - name: Thanos Receive Limits Config Reload Failure
-                description: Thanos Receive {{$labels.job}} has not been able to reload the per-tenant limits configuration file.
-                query: "sum by (job) (increase(thanos_receive_limits_config_reload_err_total[5m])) > 0"
-                severity: warning
-                for: 5m
               - name: Thanos Receive Limits High Meta Monitoring Queries Failure Rate
                 description: Thanos Receive {{$labels.job}} is failing to execute {{ $value | humanize }}% of its meta-monitoring queries.
                 query: "(sum by (job) (increase(thanos_receive_metamonitoring_failed_queries_total[5m])) / 20) * 100 > 20"
@@ -5908,9 +6677,40 @@ groups:
                 query: "sum by (job, tenant) (increase(thanos_receive_head_series_limited_requests_total[5m])) > 0"
                 severity: warning
                 for: 5m
+              - name: Thanos Receive High Forward Request Failures
+                description: "Thanos Receive {{$labels.job}} is failing to forward {{$value | humanize}}% of requests."
+                query: '(sum by (job) (rate(thanos_receive_forward_requests_total{result="error"}[5m]))/  sum by (job) (rate(thanos_receive_forward_requests_total[5m]))) * 100 > 20 and sum by (job) (rate(thanos_receive_forward_requests_total[5m])) > 0'
+                severity: info
+                for: 5m
+
+              #
+              # Info, security, and config
+              #
+              - name: Thanos Receive Config Reload Failure
+                description: "Thanos Receive {{$labels.job}} has not been able to reload hashring configurations."
+                query: 'avg by (job) (thanos_receive_config_last_reload_successful) != 1'
+                severity: warning
+                for: 5m
+              - name: Thanos Receive Limits Config Reload Failure
+                description: Thanos Receive {{$labels.job}} has not been able to reload the per-tenant limits configuration file.
+                query: "sum by (job) (increase(thanos_receive_limits_config_reload_err_total[5m])) > 0"
+                severity: warning
+                for: 5m
           - name: Thanos Sidecar
             slug: thanos-sidecar
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Thanos Sidecar No Connection To Started Prometheus
+                description: "Thanos Sidecar {{$labels.instance}} is unhealthy."
+                query: 'thanos_sidecar_prometheus_up == 0 and on (namespace, pod) prometheus_tsdb_data_replay_duration_seconds != 0'
+                severity: critical
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Sidecar Bucket Operations Failed
                 description: "Thanos Sidecar {{$labels.instance}} bucket operations are failing ({{ $value | humanize }}/s)."
                 query: 'sum by (job, instance) (rate(thanos_objstore_bucket_operation_failures_total{job=~".*thanos-sidecar.*"}[5m])) > 0.05'
@@ -5918,14 +6718,12 @@ groups:
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
                 severity: critical
                 for: 5m
-              - name: Thanos Sidecar No Connection To Started Prometheus
-                description: "Thanos Sidecar {{$labels.instance}} is unhealthy."
-                query: 'thanos_sidecar_prometheus_up == 0 and on (namespace, pod) prometheus_tsdb_data_replay_duration_seconds != 0'
-                severity: critical
-                for: 5m
           - name: Thanos Store
             slug: thanos-store
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Store Grpc Error Rate
                 description: "Thanos Store {{$labels.job}} is failing to handle {{$value | humanize}}% of requests."
                 query: '(sum by (job) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-store.*"}[5m]))/  sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*"}[5m])) * 100 > 5) and sum by (job) (rate(grpc_server_started_total{job=~".*thanos-store.*"}[5m])) > 0'
@@ -5949,6 +6747,9 @@ groups:
           - name: Thanos Ruler
             slug: thanos-ruler
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Rule Queue Is Dropping Alerts
                 description: "Thanos Rule {{$labels.instance}} is failing to queue alerts ({{ $value | humanize }}/s)."
                 query: 'sum by (job, instance) (rate(thanos_alert_queue_alerts_dropped_total[5m])) > 0'
@@ -5964,13 +6765,11 @@ groups:
                 query: '(sum by (job, instance) (rate(prometheus_rule_evaluation_failures_total{job=~".*thanos-rule.*"}[5m])) / sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) * 100 > 5) and sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) > 0'
                 severity: critical
                 for: 5m
-              - name: Thanos Rule High Rule Evaluation Warnings
-                description: "Thanos Rule {{$labels.instance}} has high number of evaluation warnings ({{ $value | humanize }}/s)."
-                query: 'sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total[5m])) > 0.05'
-                comments: |
-                  Threshold of 0.05/s avoids firing on transient single-event spikes.
-                severity: info
-                for: 15m
+              - name: Thanos No Rule Evaluations
+                description: "Thanos Rule {{$labels.instance}} did not perform any rule evaluations in the past 10 minutes."
+                query: 'sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) <= 0  and sum by (job, instance) (thanos_rule_loaded_rules) > 0'
+                severity: critical
+                for: 5m
               - name: Thanos Rule Rule Evaluation Latency High
                 description: "Thanos Rule {{$labels.instance}} has higher evaluation latency than interval for {{$labels.rule_group}}."
                 query: '(sum by (job, instance, rule_group) (prometheus_rule_group_last_duration_seconds{job=~".*thanos-rule.*"}) > sum by (job, instance, rule_group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"}))'
@@ -5980,11 +6779,6 @@ groups:
                 description: "Thanos Rule {{$labels.job}} is failing to handle {{$value | humanize}}% of requests."
                 query: '(sum by (job, instance) (rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded", job=~".*thanos-rule.*"}[5m]))/  sum by (job, instance) (rate(grpc_server_started_total{job=~".*thanos-rule.*"}[5m])) * 100 > 5) and sum by (job, instance) (rate(grpc_server_started_total{job=~".*thanos-rule.*"}[5m])) > 0'
                 severity: warning
-                for: 5m
-              - name: Thanos Rule Config Reload Failure
-                description: "Thanos Rule {{$labels.job}} has not been able to reload its configuration."
-                query: 'avg by (job, instance) (thanos_rule_config_last_reload_successful) != 1'
-                severity: info
                 for: 5m
               - name: Thanos Rule Query High D N S Failures
                 description: "Thanos Rule {{$labels.job}} has {{$value | humanize}}% of failing DNS queries for query endpoints."
@@ -5996,19 +6790,33 @@ groups:
                 query: '(sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_failures_total[5m])) / sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total[5m])) * 100 > 1) and sum by (job, instance) (rate(thanos_rule_alertmanagers_dns_lookups_total[5m])) > 0'
                 severity: warning
                 for: 15m
+              - name: Thanos Rule High Rule Evaluation Warnings
+                description: "Thanos Rule {{$labels.instance}} has high number of evaluation warnings ({{ $value | humanize }}/s)."
+                query: 'sum by (job, instance) (rate(thanos_rule_evaluation_with_warnings_total[5m])) > 0.05'
+                comments: |
+                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+                severity: info
+                for: 15m
               - name: Thanos Rule No Evaluation For10 Intervals
                 description: "Thanos Rule {{$labels.job}} has rule groups that did not evaluate for at least 10x of their expected interval."
                 query: 'time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos-rule.*"})>10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})'
                 severity: info
                 for: 5m
-              - name: Thanos No Rule Evaluations
-                description: "Thanos Rule {{$labels.instance}} did not perform any rule evaluations in the past 10 minutes."
-                query: 'sum by (job, instance) (rate(prometheus_rule_evaluations_total{job=~".*thanos-rule.*"}[5m])) <= 0  and sum by (job, instance) (thanos_rule_loaded_rules) > 0'
-                severity: critical
+
+              #
+              # Info, security, and config
+              #
+              - name: Thanos Rule Config Reload Failure
+                description: "Thanos Rule {{$labels.job}} has not been able to reload its configuration."
+                query: 'avg by (job, instance) (thanos_rule_config_last_reload_successful) != 1'
+                severity: info
                 for: 5m
           - name: Thanos Bucket Replicate
             slug: thanos-bucket-replicate
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Thanos Bucket Replicate Error Rate
                 description: "Thanos Replicate is failing to run, {{$value | humanize}}% of attempts failed."
                 query: '(sum by (job) (rate(thanos_replicate_replication_runs_total{result="error"}[5m])) / on (job) group_left sum by (job) (rate(thanos_replicate_replication_runs_total[5m]))) * 100 >= 10 and sum by (job) (rate(thanos_replicate_replication_runs_total[5m])) > 0'
@@ -6022,6 +6830,9 @@ groups:
           - name: Thanos Component Absent
             slug: thanos-component-absent
             rules:
+              #
+              # Availability
+              #
               - name: Thanos Compact Is Down
                 description: "ThanosCompact has disappeared. Prometheus target for the component cannot be discovered."
                 query: 'absent(up{job=~".*thanos-compact.*"} == 1)'
@@ -6064,10 +6875,18 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
-              - name: Loki process too many restarts
-                description: A loki process had too many restarts (target {{ $labels.instance }})
-                query: changes(process_start_time_seconds{job=~".*loki.*"}[15m]) > 2
-                severity: warning
+              #
+              # Availability
+              #
+              - name: Loki compactor not running compaction
+                description: The Loki compactor in {{ $labels.namespace }} has not completed a successful compaction in over 3 hours (or never since startup), leaving index growth unbounded and retention unenforced.
+                query: "min(time() - (loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds > 0)) by (cluster, namespace) > 10800 or max(max_over_time(loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds[3h])) by (cluster, namespace) == 0"
+                severity: critical
+                for: 1h
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Loki request errors
                 description: 'The {{ $labels.job }} and {{ $labels.route }} are experiencing {{ printf "%.2f" $value }}% errors.'
                 query: '100 * sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[1m])) by (namespace, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route) > 10 and sum(rate(loki_request_duration_seconds_count[1m])) by (namespace, job, route) > 0'
@@ -6082,22 +6901,24 @@ groups:
                 query: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{route!~"(?i).*tail.*|/schedulerpb.SchedulerForQuerier/QuerierLoop"}[5m])) by (namespace, job, route, le)) > 1
                 severity: critical
                 for: 5m
+              - name: Loki process too many restarts
+                description: A loki process had too many restarts (target {{ $labels.instance }})
+                query: changes(process_start_time_seconds{job=~".*loki.*"}[15m]) > 2
+                severity: warning
               - name: Loki too many compactors running
                 description: More than one Loki compactor is running in cluster {{ $labels.cluster }}; the compactor must run as a singleton, or index compaction and retention can be duplicated or corrupted.
                 query: "sum(loki_boltdb_shipper_compactor_running) by (cluster) > 1"
                 severity: warning
                 for: 5m
-              - name: Loki compactor not running compaction
-                description: The Loki compactor in {{ $labels.namespace }} has not completed a successful compaction in over 3 hours (or never since startup), leaving index growth unbounded and retention unenforced.
-                query: "min(time() - (loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds > 0)) by (cluster, namespace) > 10800 or max(max_over_time(loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds[3h])) by (cluster, namespace) == 0"
-                severity: critical
-                for: 1h
       - name: Promtail
         logo: /images/services/promtail.svg
         exporters:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Promtail request errors
                 description: The {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors.
                 query: '100 * sum(rate(promtail_request_duration_seconds_count{status_code=~"5..|failed"}[1m])) by (namespace, job, route, instance) / sum(rate(promtail_request_duration_seconds_count[1m])) by (namespace, job, route, instance) > 10 and sum(rate(promtail_request_duration_seconds_count[1m])) by (namespace, job, route, instance) > 0'
@@ -6119,14 +6940,38 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
-              - name: Cortex ruler configuration reload failure
-                description: Cortex ruler configuration reload failure (instance {{ $labels.instance }})
-                query: cortex_ruler_config_last_reload_successful != 1
-                severity: warning
+              #
+              # Availability
+              #
               - name: Cortex not connected to Alertmanager
                 description: Cortex not connected to Alertmanager (instance {{ $labels.instance }})
                 query: cortex_prometheus_notifications_alertmanagers_discovered < 1
                 severity: critical
+              - name: Cortex Alertmanager state replication failing
+                description: Cortex Alertmanager {{ $labels.instance }} is failing to replicate its state to replicas, risking loss of silence/notification state on failover.
+                query: "rate(cortex_alertmanager_state_replication_failed_total[5m]) > 0.05"
+                severity: critical
+                for: 10m
+                comments: |
+                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+              - name: Cortex ruler missed evaluations
+                description: 'Cortex ruler {{ $labels.instance }} is missing {{ printf "%.2f" $value }}% of evaluation iterations for rule group {{ $labels.rule_group }}, meaning alerting/recording rules are not evaluated on schedule.'
+                query: "100 * sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 1 and sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0"
+                severity: warning
+                for: 5m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Cortex compactor has not uploaded blocks
+                description: Cortex compactor {{ $labels.instance }} has not uploaded any compacted block to storage in the last 24 hours.
+                query: '(time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 86400) and (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 0)'
+                severity: critical
+                for: 15m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Cortex notifications are being dropped
                 description: "Cortex notifications are being dropped due to errors (instance {{ $labels.instance }}, {{ $value | humanize }}/s)."
                 query: rate(cortex_prometheus_notifications_dropped_total[5m]) > 0.05
@@ -6162,11 +7007,6 @@ groups:
               - name: Cortex KV store failure
                 description: Cortex {{ $labels.pod }} is failing to talk to the ring KV store {{ $labels.kv_name }} (etcd/consul/memberlist), which ring-based components rely on to coordinate.
                 query: '(sum by (pod, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[5m])) / sum by (pod, kv_name) (rate(cortex_kv_request_duration_seconds_count[5m]))) == 1 and sum by (pod, kv_name) (rate(cortex_kv_request_duration_seconds_count[5m])) > 0'
-                severity: critical
-                for: 5m
-              - name: Cortex runtime config reload failure
-                description: Cortex {{ $labels.job }} failed to reload its runtime configuration (limits overrides, etc.). This is distinct from ruler-specific rule group reloads.
-                query: "cortex_runtime_config_last_reload_successful == 0"
                 severity: critical
                 for: 5m
               - name: Cortex query-scheduler queries stuck
@@ -6209,18 +7049,6 @@ groups:
                 query: "(time() - cortex_compactor_last_successful_run_timestamp_seconds > 86400) and (cortex_compactor_last_successful_run_timestamp_seconds > 0)"
                 severity: critical
                 for: 15m
-              - name: Cortex compactor has not uploaded blocks
-                description: Cortex compactor {{ $labels.instance }} has not uploaded any compacted block to storage in the last 24 hours.
-                query: '(time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 86400) and (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 0)'
-                severity: critical
-                for: 15m
-              - name: Cortex Alertmanager config sync failing
-                description: Cortex Alertmanager {{ $labels.instance }} is failing to read tenant configurations from storage.
-                query: "rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0.05"
-                severity: critical
-                for: 30m
-                comments: |
-                  Threshold of 0.05/s avoids firing on transient single-event spikes.
               - name: Cortex Alertmanager ring check failing
                 description: Cortex Alertmanager {{ $labels.instance }} is unable to check tenant ownership via the ring, which can cause misrouted or dropped alert notifications.
                 query: "rate(cortex_alertmanager_ring_check_errors_total[5m]) > 0.05"
@@ -6228,13 +7056,15 @@ groups:
                 for: 10m
                 comments: |
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
-              - name: Cortex Alertmanager state replication failing
-                description: Cortex Alertmanager {{ $labels.instance }} is failing to replicate its state to replicas, risking loss of silence/notification state on failover.
-                query: "rate(cortex_alertmanager_state_replication_failed_total[5m]) > 0.05"
+              - name: Cortex ruler too many failed pushes
+                description: 'Cortex ruler {{ $labels.instance }} is failing to push {{ printf "%.2f" $value }}% of write requests when writing rule evaluation results back to Cortex.'
+                query: "100 * (sum by (instance, job) (rate(cortex_ruler_write_requests_failed_total[5m])) / sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m]))) > 1 and sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m])) > 0"
                 severity: critical
-                for: 10m
-                comments: |
-                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+                for: 5m
+
+              #
+              # Capacity and trend
+              #
               - name: Cortex Alertmanager state persist failing
                 description: Cortex Alertmanager {{ $labels.instance }} is unable to persist full state snapshots to remote storage, risking loss of silences and notification state on restart.
                 query: "rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0.05"
@@ -6242,16 +7072,26 @@ groups:
                 for: 1h
                 comments: |
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
-              - name: Cortex ruler too many failed pushes
-                description: 'Cortex ruler {{ $labels.instance }} is failing to push {{ printf "%.2f" $value }}% of write requests when writing rule evaluation results back to Cortex.'
-                query: "100 * (sum by (instance, job) (rate(cortex_ruler_write_requests_failed_total[5m])) / sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m]))) > 1 and sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m])) > 0"
+
+              #
+              # Info, security, and config
+              #
+              - name: Cortex runtime config reload failure
+                description: Cortex {{ $labels.job }} failed to reload its runtime configuration (limits overrides, etc.). This is distinct from ruler-specific rule group reloads.
+                query: "cortex_runtime_config_last_reload_successful == 0"
                 severity: critical
                 for: 5m
-              - name: Cortex ruler missed evaluations
-                description: 'Cortex ruler {{ $labels.instance }} is missing {{ printf "%.2f" $value }}% of evaluation iterations for rule group {{ $labels.rule_group }}, meaning alerting/recording rules are not evaluated on schedule.'
-                query: "100 * sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 1 and sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0"
+              - name: Cortex Alertmanager config sync failing
+                description: Cortex Alertmanager {{ $labels.instance }} is failing to read tenant configurations from storage.
+                query: "rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0.05"
+                severity: critical
+                for: 30m
+                comments: |
+                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+              - name: Cortex ruler configuration reload failure
+                description: Cortex ruler configuration reload failure (instance {{ $labels.instance }})
+                query: cortex_ruler_config_last_reload_successful != 1
                 severity: warning
-                for: 5m
 
       - name: Grafana Tempo
         logo: /images/services/grafana-tempo.svg
@@ -6266,11 +7106,9 @@ groups:
               (distributor -> Kafka -> block-builder/live-store). On a classic/monolithic Tempo
               deployment those specific metrics won't exist and their rules will simply stay inactive.
             rules:
-              - name: Tempo distributor unhealthy
-                description: Tempo has {{ $value }} unhealthy distributor(s).
-                query: max by (job) (tempo_ring_members{state="Unhealthy", name="distributor"}) > 0
-                severity: warning
-                for: 15m
+              #
+              # Performance and errors (RED)
+              #
               - name: Tempo live store unhealthy
                 description: Tempo has {{ $value }} unhealthy live store(s).
                 query: max by (job) (tempo_ring_members{state="Unhealthy", name="live-store"}) > 0
@@ -6315,22 +7153,6 @@ groups:
                 for: 15m
                 comments: |
                   Fires when the blocklist grows more than 40% over 7 days.
-              - name: Tempo bad overrides
-                description: '{{ $labels.job }} failed to reload runtime overrides.'
-                query: sum by (job) (tempo_runtime_config_last_reload_successful == 0) > 0
-                severity: critical
-                for: 15m
-              - name: Tempo user configurable overrides reload failing
-                description: "{{ $value }} user-configurable overrides reloads have failed in the past hour."
-                query: sum by (job) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total[1h])) > 5 and sum by (job) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total[5m])) > 0
-                severity: critical
-              - name: Tempo compaction too many outstanding blocks warning
-                description: There are too many outstanding compaction blocks for {{ $labels.instance }}. Consider increasing compactor resources.
-                query: sum by (instance) (tempodb_compaction_outstanding_blocks) > 100
-                severity: warning
-                for: 6h
-                comments: |
-                  Threshold of 100 blocks per compactor instance. Adjust based on your environment.
               - name: Tempo compaction too many outstanding blocks critical
                 description: There are too many outstanding compaction blocks for {{ $labels.instance }}. Increase compactor resources immediately.
                 query: sum by (instance) (tempodb_compaction_outstanding_blocks) > 250
@@ -6353,23 +7175,11 @@ groups:
                 query: sum by (job) (increase(tempo_metrics_generator_active_processors_update_failed_total[5m])) > 2
                 severity: critical
                 for: 15m
-              - name: Tempo metrics generator service graphs dropping spans
-                description: Tempo metrics generator is dropping {{ printf "%.2f" $value }}% of spans in service graphs for {{ $labels.job }}.
-                query: '100 * sum by (job) (rate(tempo_metrics_generator_processor_service_graphs_dropped_spans_total[5m])) / sum by (job) (rate(tempo_metrics_generator_spans_received_total[5m])) > 0.5 and sum by (job) (rate(tempo_metrics_generator_spans_received_total[5m])) > 0'
-                severity: warning
-                for: 15m
               - name: Tempo metrics generator collections failing
                 description: "Tempo metrics generator collections are failing for {{ $labels.job }} ({{ $value }} failures in 5m)."
                 query: sum by (job) (increase(tempo_metrics_generator_registry_collections_failed_total[5m])) > 2
                 severity: critical
                 for: 5m
-              - name: Tempo memcached errors elevated
-                description: 'Tempo memcached error rate is {{ printf "%.2f" $value }}% for {{ $labels.name }} in {{ $labels.job }}.'
-                query: '100 * sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count{status_code="500"}[5m])) / sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count[5m])) > 20 and sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count[5m])) > 0'
-                severity: warning
-                for: 10m
-                comments: |
-                  Fires when the memcached error rate exceeds 20%. Only relevant if Tempo is configured with memcached caching.
               - name: Tempo distributor Kafka produce failures
                 description: 'Tempo distributor {{ $labels.job }} is failing to produce {{ printf "%.2f" $value }}% of trace records to Kafka, an early indicator of write-path trace loss.'
                 query: '100 * sum by (job) (rate(tempo_distributor_produce_failures_total{reason!="cancelled-before-producing"}[5m])) / sum by (job) (rate(tempo_distributor_produce_records_total[5m])) > 0.1 and sum by (job) (rate(tempo_distributor_produce_records_total[5m])) > 0'
@@ -6379,11 +7189,6 @@ groups:
                 description: All live-store owners of Tempo partition {{ $labels.partition }} are lagging by {{ $value }}s behind their Kafka ingest partition, causing a partial read outage for recent traces.
                 query: 'min by (job, partition) (tempo_ingest_group_partition_lag_seconds{container="live-store"}) > 300'
                 severity: critical
-                for: 2m
-              - name: Tempo live store partition lag warning
-                description: Tempo live-store {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}, degrading read completeness for recent traces.
-                query: 'tempo_ingest_group_partition_lag_seconds{container="live-store"} > 200'
-                severity: warning
                 for: 2m
               - name: Tempo live store partition lag critical
                 description: Tempo live-store {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}; recent traces on this partition may be significantly delayed.
@@ -6395,15 +7200,6 @@ groups:
                 query: 'max by (job) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive"}) > count(count by (partition, job) (tempo_live_store_partition_owned)) by (job)'
                 severity: critical
                 for: 10m
-              - name: Tempo block builder partition lag warning
-                description: Tempo block-builder {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}; traces are delayed in being flushed into durable blocks.
-                query: 'avg_over_time(tempo_ingest_group_partition_lag_seconds{container="block-builder"}[6m]) > 200'
-                severity: warning
-                comments: |
-                  The block-builder consumes in batches, so its raw lag sawtooths up to consume_cycle_duration
-                  (5m by default) on every healthy cycle. The 6m average is what makes 200s meaningful: it
-                  means the block-builder is burning roughly 45% of its cycle budget. Raise the window
-                  alongside consume_cycle_duration if you tune it.
               - name: Tempo block builder partition lag critical
                 description: Tempo block-builder {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}; traces are significantly delayed in being flushed into durable blocks.
                 query: 'tempo_ingest_group_partition_lag_seconds{container="block-builder"} > 300'
@@ -6424,6 +7220,57 @@ groups:
                 query: 'max by (job) (tempo_partition_ring_partitions{name="livestore-partitions", state=~"Active|Inactive"}) > sum by (job) (tempo_block_builder_owned_partitions)'
                 severity: critical
                 for: 10m
+              - name: Tempo distributor unhealthy
+                description: Tempo has {{ $value }} unhealthy distributor(s).
+                query: max by (job) (tempo_ring_members{state="Unhealthy", name="distributor"}) > 0
+                severity: warning
+                for: 15m
+              - name: Tempo compaction too many outstanding blocks warning
+                description: There are too many outstanding compaction blocks for {{ $labels.instance }}. Consider increasing compactor resources.
+                query: sum by (instance) (tempodb_compaction_outstanding_blocks) > 100
+                severity: warning
+                for: 6h
+                comments: |
+                  Threshold of 100 blocks per compactor instance. Adjust based on your environment.
+              - name: Tempo metrics generator service graphs dropping spans
+                description: Tempo metrics generator is dropping {{ printf "%.2f" $value }}% of spans in service graphs for {{ $labels.job }}.
+                query: '100 * sum by (job) (rate(tempo_metrics_generator_processor_service_graphs_dropped_spans_total[5m])) / sum by (job) (rate(tempo_metrics_generator_spans_received_total[5m])) > 0.5 and sum by (job) (rate(tempo_metrics_generator_spans_received_total[5m])) > 0'
+                severity: warning
+                for: 15m
+              - name: Tempo memcached errors elevated
+                description: 'Tempo memcached error rate is {{ printf "%.2f" $value }}% for {{ $labels.name }} in {{ $labels.job }}.'
+                query: '100 * sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count{status_code="500"}[5m])) / sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count[5m])) > 20 and sum by (name, job) (rate(tempo_memcache_request_duration_seconds_count[5m])) > 0'
+                severity: warning
+                for: 10m
+                comments: |
+                  Fires when the memcached error rate exceeds 20%. Only relevant if Tempo is configured with memcached caching.
+              - name: Tempo live store partition lag warning
+                description: Tempo live-store {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}, degrading read completeness for recent traces.
+                query: 'tempo_ingest_group_partition_lag_seconds{container="live-store"} > 200'
+                severity: warning
+                for: 2m
+              - name: Tempo block builder partition lag warning
+                description: Tempo block-builder {{ $labels.instance }} (group {{ $labels.group }}) is lagging by {{ $value }}s behind Kafka ingest partition {{ $labels.partition }}; traces are delayed in being flushed into durable blocks.
+                query: 'avg_over_time(tempo_ingest_group_partition_lag_seconds{container="block-builder"}[6m]) > 200'
+                severity: warning
+                comments: |
+                  The block-builder consumes in batches, so its raw lag sawtooths up to consume_cycle_duration
+                  (5m by default) on every healthy cycle. The 6m average is what makes 200s meaningful: it
+                  means the block-builder is burning roughly 45% of its cycle budget. Raise the window
+                  alongside consume_cycle_duration if you tune it.
+
+              #
+              # Info, security, and config
+              #
+              - name: Tempo bad overrides
+                description: '{{ $labels.job }} failed to reload runtime overrides.'
+                query: sum by (job) (tempo_runtime_config_last_reload_successful == 0) > 0
+                severity: critical
+                for: 15m
+              - name: Tempo user configurable overrides reload failing
+                description: "{{ $value }} user-configurable overrides reloads have failed in the past hour."
+                query: sum by (job) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total[1h])) > 5 and sum by (job) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total[5m])) > 0
+                severity: critical
 
       - name: Grafana Mimir
         logo: /images/services/grafana-mimir.svg
@@ -6434,7 +7281,73 @@ groups:
             comments: |
               Mimir uses the `cortex_` metric prefix for backward compatibility with Cortex. This is intentional and expected.
             rules:
-              # Core alerts
+              #
+              # Availability
+              #
+              - name: Mimir compactor not running compaction
+                description: Mimir compactor {{ $labels.instance }} has not run compaction in the last 24 hours.
+                query: (time() - cortex_compactor_last_successful_run_timestamp_seconds > 86400) and cortex_compactor_last_successful_run_timestamp_seconds > 0
+                severity: critical
+                for: 15m
+              - name: Mimir ruler missed evaluations
+                description: 'Mimir ruler {{ $labels.instance }} is missing {{ printf "%.2f" $value }}% of rule group evaluations.'
+                query: '100 * sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 5 and sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0'
+                severity: warning
+                for: 5m
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: Mimir memory map areas too high
+                description: 'Mimir {{ $labels.job }} is using {{ printf "%.0f" $value }}% of its memory map area limit.'
+                query: 'process_memory_map_areas{job=~".*(ingester|cortex|mimir|store-gateway).*"} / process_memory_map_areas_limit{job=~".*(ingester|cortex|mimir|store-gateway).*"} * 100 > 80 and process_memory_map_areas_limit{job=~".*(ingester|cortex|mimir|store-gateway).*"} > 0'
+                severity: critical
+                for: 5m
+              - name: Mimir ingester reaching series limit critical
+                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its series limit.'
+                query: '(cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"} * 100 > 90) and cortex_ingester_instance_limits{limit="max_series"} > 0'
+                severity: critical
+                for: 5m
+              - name: Mimir ingester reaching tenants limit critical
+                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its tenants limit.'
+                query: '(cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"} * 100 > 80) and cortex_ingester_instance_limits{limit="max_tenants"} > 0'
+                severity: critical
+                for: 5m
+              - name: Mimir ingester instance has no tenants
+                description: Mimir ingester {{ $labels.instance }} has no tenants assigned.
+                query: (cortex_ingester_memory_users == 0) and on (instance) (cortex_ingester_memory_users offset 1h > 0)
+                severity: warning
+                for: 1h
+              - name: Mimir ingester reaching series limit warning
+                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its series limit.'
+                query: '(cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"} * 100 > 80) and cortex_ingester_instance_limits{limit="max_series"} > 0'
+                severity: warning
+                for: 3h
+              - name: Mimir ingester reaching tenants limit warning
+                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its tenants limit.'
+                query: '(cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"} * 100 > 70) and cortex_ingester_instance_limits{limit="max_tenants"} > 0'
+                severity: warning
+                for: 5m
+              - name: Mimir compactor has run out of disk space
+                description: Mimir compactor {{ $labels.instance }} has run out of disk space.
+                query: delta(cortex_compactor_disk_out_of_space_errors_total[24h]) >= 1
+                comments: |
+                  cortex_compactor_disk_out_of_space_errors_total is declared as gauge by Mimir despite the _total suffix, so delta() is used instead of increase().
+                severity: critical
+              - name: Mimir ingester has unshipped blocks
+                description: Mimir ingester {{ $labels.instance }} compacted its TSDB head into a local block more than 1 hour ago but has not yet uploaded it to object storage.
+                query: "(time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600) and (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)"
+                severity: critical
+                for: 15m
+              - name: Mimir reaching TCP connections limit
+                description: 'Mimir instance {{ $labels.instance }} is using {{ printf "%.0f" $value }}% of its TCP connections limit.'
+                query: cortex_tcp_connections / cortex_tcp_connections_limit * 100 > 80 and cortex_tcp_connections_limit > 0
+                severity: critical
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Mimir ingester unhealthy
                 description: Mimir has {{ $value }} unhealthy ingester(s) in the ring.
                 query: min by (job) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
@@ -6445,87 +7358,14 @@ groups:
                 query: '100 * sum by (job, route) (rate(cortex_request_duration_seconds_count{status_code=~"5..", route!~"ready|debug_pprof"}[5m])) / sum by (job, route) (rate(cortex_request_duration_seconds_count{route!~"ready|debug_pprof"}[5m])) > 1 and sum by (job, route) (rate(cortex_request_duration_seconds_count{route!~"ready|debug_pprof"}[5m])) > 0'
                 severity: critical
                 for: 15m
-              - name: Mimir inconsistent runtime config
-                description: An inconsistent runtime config file is used across Mimir instances.
-                query: count(count by (job, sha256) (cortex_runtime_config_hash)) without(sha256) > 1
-                severity: critical
-                for: 1h
-              - name: Mimir bad runtime config
-                description: '{{ $labels.job }} failed to reload runtime config.'
-                query: sum by (job) (cortex_runtime_config_last_reload_successful == 0) > 0
-                severity: critical
-                for: 5m
               - name: Mimir scheduler queries stuck
                 description: There are {{ $value }} queued up queries in {{ $labels.job }}.
                 query: sum by (job) (min_over_time(cortex_query_scheduler_queue_length[1m])) > 0
                 severity: critical
                 for: 7m
-              - name: Mimir cache request errors
-                description: 'Mimir cache {{ $labels.name }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.'
-                query: '(sum by (name, operation, job) (rate(thanos_cache_operation_failures_total[5m])) / sum by (name, operation, job) (rate(thanos_cache_operations_total[5m]))) * 100 > 5 and sum by (name, operation, job) (rate(thanos_cache_operations_total[5m])) > 0'
-                severity: warning
-                for: 5m
               - name: Mimir KV store failure
                 description: 'Mimir {{ $labels.job }} KV store {{ $labels.kv_name }} is failing with 100% error rate.'
                 query: '(sum by (job, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.."}[5m])) / sum by (job, kv_name) (rate(cortex_kv_request_duration_seconds_count[5m]))) == 1 and sum by (job, kv_name) (rate(cortex_kv_request_duration_seconds_count[5m])) > 0'
-                severity: critical
-                for: 5m
-              - name: Mimir memory map areas too high
-                description: 'Mimir {{ $labels.job }} is using {{ printf "%.0f" $value }}% of its memory map area limit.'
-                query: 'process_memory_map_areas{job=~".*(ingester|cortex|mimir|store-gateway).*"} / process_memory_map_areas_limit{job=~".*(ingester|cortex|mimir|store-gateway).*"} * 100 > 80 and process_memory_map_areas_limit{job=~".*(ingester|cortex|mimir|store-gateway).*"} > 0'
-                severity: critical
-                for: 5m
-              - name: Mimir ingester instance has no tenants
-                description: Mimir ingester {{ $labels.instance }} has no tenants assigned.
-                query: (cortex_ingester_memory_users == 0) and on (instance) (cortex_ingester_memory_users offset 1h > 0)
-                severity: warning
-                for: 1h
-              - name: Mimir ruler instance has no rule groups
-                description: Mimir ruler {{ $labels.instance }} has no rule groups assigned.
-                query: (cortex_ruler_managers_total == 0) and on (instance) (cortex_ruler_managers_total offset 1h > 0)
-                severity: warning
-                for: 1h
-              - name: Mimir ingested data too far in the future
-                description: Mimir ingester {{ $labels.job }} has ingested samples with timestamps more than 1 hour in the future.
-                query: max by (job) (cortex_ingester_tsdb_head_max_timestamp_seconds - time() and cortex_ingester_tsdb_head_max_timestamp_seconds > 0) > 3600
-                severity: warning
-                for: 5m
-              - name: Mimir store gateway too many failed operations
-                description: Mimir store-gateway {{ $labels.job }} bucket operations are failing ({{ $value | humanize }}/s).
-                query: sum by (job) (rate(thanos_objstore_bucket_operation_failures_total[5m])) > 0.05
-                comments: |
-                  Threshold of 0.05/s avoids firing on transient single-event spikes.
-                severity: warning
-                for: 5m
-              - name: Mimir ring members mismatch
-                description: Mimir {{ $labels.name }} ring has inconsistent member counts across instances.
-                query: max by (name, job) (sum by (name, job, instance) (cortex_ring_members)) != min by (name, job) (sum by (name, job, instance) (cortex_ring_members))
-                severity: warning
-                for: 15m
-              # Instance limits
-              - name: Mimir ingester reaching series limit warning
-                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its series limit.'
-                query: '(cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"} * 100 > 80) and cortex_ingester_instance_limits{limit="max_series"} > 0'
-                severity: warning
-                for: 3h
-              - name: Mimir ingester reaching series limit critical
-                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its series limit.'
-                query: '(cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"} * 100 > 90) and cortex_ingester_instance_limits{limit="max_series"} > 0'
-                severity: critical
-                for: 5m
-              - name: Mimir ingester reaching tenants limit warning
-                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its tenants limit.'
-                query: '(cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"} * 100 > 70) and cortex_ingester_instance_limits{limit="max_tenants"} > 0'
-                severity: warning
-                for: 5m
-              - name: Mimir ingester reaching tenants limit critical
-                description: 'Mimir ingester {{ $labels.instance }} has reached {{ printf "%.0f" $value }}% of its tenants limit.'
-                query: '(cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"} * 100 > 80) and cortex_ingester_instance_limits{limit="max_tenants"} > 0'
-                severity: critical
-                for: 5m
-              - name: Mimir reaching TCP connections limit
-                description: 'Mimir instance {{ $labels.instance }} is using {{ printf "%.0f" $value }}% of its TCP connections limit.'
-                query: cortex_tcp_connections / cortex_tcp_connections_limit * 100 > 80 and cortex_tcp_connections_limit > 0
                 severity: critical
                 for: 5m
               - name: Mimir distributor inflight requests high
@@ -6561,12 +7401,6 @@ groups:
                 severity: critical
                 comments: |
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
-              - name: Mimir ingester TSDB WAL truncation failed
-                description: "Mimir ingester {{ $labels.instance }} is failing to truncate TSDB WAL ({{ $value | humanize }}/s)."
-                query: rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0.05
-                severity: warning
-                comments: |
-                  Threshold of 0.05/s avoids firing on transient single-event spikes.
               - name: Mimir ingester TSDB WAL writes failed
                 description: "Mimir ingester {{ $labels.instance }} is failing to write to TSDB WAL ({{ $value | humanize }}/s)."
                 query: rate(cortex_ingester_tsdb_wal_writes_failed_total[1m]) > 0.05
@@ -6581,11 +7415,6 @@ groups:
                   Threshold of 30 minutes. Adjust based on your sync interval.
                 severity: critical
                 for: 5m
-              - name: Mimir store gateway no synced tenants
-                description: Mimir store-gateway {{ $labels.instance }} has no synced tenants.
-                query: (min by (instance, job) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0) and on (instance) (cortex_bucket_stores_tenants_synced{component="store-gateway"} offset 1h > 0)
-                severity: warning
-                for: 1h
               - name: Mimir bucket index not updated
                 description: 'Mimir bucket index for tenant {{ $labels.user }} has not been updated for more than 35 minutes.'
                 query: min by (user, job) (time() - cortex_bucket_index_last_successful_update_timestamp_seconds) > 2100
@@ -6596,34 +7425,15 @@ groups:
                 query: (time() - cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 21600) and cortex_compactor_block_cleanup_last_successful_run_timestamp_seconds > 0
                 severity: critical
                 for: 1h
-              - name: Mimir compactor not running compaction
-                description: Mimir compactor {{ $labels.instance }} has not run compaction in the last 24 hours.
-                query: (time() - cortex_compactor_last_successful_run_timestamp_seconds > 86400) and cortex_compactor_last_successful_run_timestamp_seconds > 0
-                severity: critical
-                for: 15m
               - name: Mimir compactor has consecutive failures
                 description: "Mimir compactor {{ $labels.instance }} has had {{ $value }} compaction failures in the last 2 hours."
                 query: increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) > 1
-                severity: critical
-              - name: Mimir compactor has run out of disk space
-                description: Mimir compactor {{ $labels.instance }} has run out of disk space.
-                query: delta(cortex_compactor_disk_out_of_space_errors_total[24h]) >= 1
-                comments: |
-                  cortex_compactor_disk_out_of_space_errors_total is declared as gauge by Mimir despite the _total suffix, so delta() is used instead of increase().
                 severity: critical
               - name: Mimir compactor has not uploaded blocks
                 description: Mimir compactor {{ $labels.instance }} has not uploaded any block in the last 24 hours.
                 query: (time() - thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 86400) and thanos_objstore_bucket_last_successful_upload_time{component="compactor"} > 0
                 severity: critical
                 for: 15m
-              - name: Mimir compactor skipped blocks
-                description: "Mimir compactor has found {{ $value }} blocks that cannot be compacted (reason {{ $labels.reason }})."
-                query: increase(cortex_compactor_blocks_marked_for_no_compaction_total[24h]) > 0
-                comments: |
-                  Using a 24h window as compaction skips are rare events.
-                severity: warning
-                for: 5m
-              # Ruler
               - name: Mimir ruler too many failed pushes
                 description: 'Mimir ruler {{ $labels.instance }} is failing to push {{ printf "%.2f" $value }}% of write requests.'
                 query: '100 * sum by (instance, job) (rate(cortex_ruler_write_requests_failed_total[5m])) / sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m])) > 1 and sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m])) > 0'
@@ -6633,11 +7443,6 @@ groups:
                 description: 'Mimir ruler {{ $labels.instance }} is failing {{ printf "%.2f" $value }}% of query evaluations.'
                 query: '100 * sum by (instance, job) (rate(cortex_ruler_queries_failed_total[5m])) / sum by (instance, job) (rate(cortex_ruler_queries_total[5m])) > 1 and sum by (instance, job) (rate(cortex_ruler_queries_total[5m])) > 0'
                 severity: critical
-                for: 5m
-              - name: Mimir ruler missed evaluations
-                description: 'Mimir ruler {{ $labels.instance }} is missing {{ printf "%.2f" $value }}% of rule group evaluations.'
-                query: '100 * sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 5 and sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0'
-                severity: warning
                 for: 5m
               - name: Mimir ruler failed ring check
                 description: Mimir ruler {{ $labels.job }} is failing ring checks ({{ $value | humanize }}/s).
@@ -6682,6 +7487,73 @@ groups:
                 for: 1h
                 comments: |
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
+              - name: Mimir go threads too high critical
+                description: 'Mimir {{ $labels.instance }} has {{ $value }} Go threads.'
+                query: 'go_threads{job=~".*(mimir|cortex).*"} > 8000'
+                severity: critical
+                for: 15m
+              - name: Mimir ingester not shipping blocks
+                description: Mimir ingester {{ $labels.instance }} has not shipped any TSDB block to object storage in the last 4 hours despite actively ingesting samples, risking data loss if the ingester is replaced or crashes.
+                query: "(time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds > 4 * 3600) and (cortex_ingester_shipper_last_successful_upload_timestamp_seconds > 0) and (rate(cortex_ingester_ingested_samples_total[5m]) > 0)"
+                severity: critical
+                for: 15m
+              - name: Mimir ingester TSDB WAL corrupted
+                description: Mimir ingester in {{ $labels.job }} detected a corrupted TSDB write-ahead log, risking sample loss when the ingester restarts and replays the WAL.
+                query: "count by (job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1"
+                severity: critical
+              - name: Mimir compactor never run compaction critical
+                description: Mimir compactor {{ $labels.instance }} has not run compaction since it started, over 12 hours ago.
+                query: "cortex_compactor_last_successful_run_timestamp_seconds == 0"
+                severity: critical
+                for: 12h
+              # Core alerts
+              - name: Mimir cache request errors
+                description: 'Mimir cache {{ $labels.name }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.'
+                query: '(sum by (name, operation, job) (rate(thanos_cache_operation_failures_total[5m])) / sum by (name, operation, job) (rate(thanos_cache_operations_total[5m]))) * 100 > 5 and sum by (name, operation, job) (rate(thanos_cache_operations_total[5m])) > 0'
+                severity: warning
+                for: 5m
+              - name: Mimir ruler instance has no rule groups
+                description: Mimir ruler {{ $labels.instance }} has no rule groups assigned.
+                query: (cortex_ruler_managers_total == 0) and on (instance) (cortex_ruler_managers_total offset 1h > 0)
+                severity: warning
+                for: 1h
+              - name: Mimir ingested data too far in the future
+                description: Mimir ingester {{ $labels.job }} has ingested samples with timestamps more than 1 hour in the future.
+                query: max by (job) (cortex_ingester_tsdb_head_max_timestamp_seconds - time() and cortex_ingester_tsdb_head_max_timestamp_seconds > 0) > 3600
+                severity: warning
+                for: 5m
+              - name: Mimir store gateway too many failed operations
+                description: Mimir store-gateway {{ $labels.job }} bucket operations are failing ({{ $value | humanize }}/s).
+                query: sum by (job) (rate(thanos_objstore_bucket_operation_failures_total[5m])) > 0.05
+                comments: |
+                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+                severity: warning
+                for: 5m
+              - name: Mimir ring members mismatch
+                description: Mimir {{ $labels.name }} ring has inconsistent member counts across instances.
+                query: max by (name, job) (sum by (name, job, instance) (cortex_ring_members)) != min by (name, job) (sum by (name, job, instance) (cortex_ring_members))
+                severity: warning
+                for: 15m
+              # Instance limits
+              - name: Mimir ingester TSDB WAL truncation failed
+                description: "Mimir ingester {{ $labels.instance }} is failing to truncate TSDB WAL ({{ $value | humanize }}/s)."
+                query: rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0.05
+                severity: warning
+                comments: |
+                  Threshold of 0.05/s avoids firing on transient single-event spikes.
+              - name: Mimir store gateway no synced tenants
+                description: Mimir store-gateway {{ $labels.instance }} has no synced tenants.
+                query: (min by (instance, job) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0) and on (instance) (cortex_bucket_stores_tenants_synced{component="store-gateway"} offset 1h > 0)
+                severity: warning
+                for: 1h
+              - name: Mimir compactor skipped blocks
+                description: "Mimir compactor has found {{ $value }} blocks that cannot be compacted (reason {{ $labels.reason }})."
+                query: increase(cortex_compactor_blocks_marked_for_no_compaction_total[24h]) > 0
+                comments: |
+                  Using a 24h window as compaction skips are rare events.
+                severity: warning
+                for: 5m
+              # Ruler
               - name: Mimir alertmanager initial sync failed
                 description: Mimir alertmanager {{ $labels.job }} failed initial state sync.
                 query: increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[1m]) > 0
@@ -6710,40 +7582,30 @@ groups:
                 for: 15m
                 comments: |
                   A high number of Go threads may indicate a goroutine leak.
-              - name: Mimir go threads too high critical
-                description: 'Mimir {{ $labels.instance }} has {{ $value }} Go threads.'
-                query: 'go_threads{job=~".*(mimir|cortex).*"} > 8000'
-                severity: critical
-                for: 15m
-              - name: Mimir ingester not shipping blocks
-                description: Mimir ingester {{ $labels.instance }} has not shipped any TSDB block to object storage in the last 4 hours despite actively ingesting samples, risking data loss if the ingester is replaced or crashes.
-                query: "(time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds > 4 * 3600) and (cortex_ingester_shipper_last_successful_upload_timestamp_seconds > 0) and (rate(cortex_ingester_ingested_samples_total[5m]) > 0)"
-                severity: critical
-                for: 15m
-              - name: Mimir ingester has unshipped blocks
-                description: Mimir ingester {{ $labels.instance }} compacted its TSDB head into a local block more than 1 hour ago but has not yet uploaded it to object storage.
-                query: "(time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600) and (cortex_ingester_oldest_unshipped_block_timestamp_seconds > 0)"
-                severity: critical
-                for: 15m
-              - name: Mimir ingester TSDB WAL corrupted
-                description: Mimir ingester in {{ $labels.job }} detected a corrupted TSDB write-ahead log, risking sample loss when the ingester restarts and replays the WAL.
-                query: "count by (job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1"
-                severity: critical
               - name: Mimir compactor never run compaction warning
                 description: Mimir compactor {{ $labels.instance }} has not run compaction since it started, over 6 hours ago.
                 query: "cortex_compactor_last_successful_run_timestamp_seconds == 0"
                 severity: warning
                 for: 6h
-              - name: Mimir compactor never run compaction critical
-                description: Mimir compactor {{ $labels.instance }} has not run compaction since it started, over 12 hours ago.
-                query: "cortex_compactor_last_successful_run_timestamp_seconds == 0"
-                severity: critical
-                for: 12h
               - name: Mimir request latency high
                 description: Mimir {{ $labels.job }} {{ $labels.route }} is experiencing a p99 request latency of {{ $value }}s.
                 query: 'histogram_quantile(0.99, sum by (job, route, le) (rate(cortex_request_duration_seconds_bucket{route!~"ready|debug_pprof"}[5m]))) > 2.5'
                 severity: warning
                 for: 15m
+
+              #
+              # Info, security, and config
+              #
+              - name: Mimir inconsistent runtime config
+                description: An inconsistent runtime config file is used across Mimir instances.
+                query: count(count by (job, sha256) (cortex_runtime_config_hash)) without(sha256) > 1
+                severity: critical
+                for: 1h
+              - name: Mimir bad runtime config
+                description: '{{ $labels.job }} failed to reload runtime config.'
+                query: sum by (job) (cortex_runtime_config_last_reload_successful == 0) > 0
+                severity: critical
+                for: 5m
 
       - name: Grafana Alloy
         logo: /images/services/grafana-alloy.svg
@@ -6751,10 +7613,27 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Availability
+              #
               - name: Grafana Alloy service down
                 description: "Alloy on instance {{ $labels.instance }} is not responding or has stopped running."
                 query: "count by (instance) (alloy_build_info offset 2h) unless count by (instance) (alloy_build_info)"
                 severity: critical
+              - name: Grafana Alloy OpenTelemetry exporter failing to send data
+                description: The OpenTelemetry exporter in Alloy under job {{ $labels.job }} has a success rate below 95% for sending spans, metrics, or logs to their destination, meaning telemetry data delivery is failing, possibly due to a payload issue or an unreachable endpoint.
+                query: '(1 - (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) / (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) + sum by (job) (rate({__name__=~"otelcol_exporter_sent_(spans|metric_points|log_records)_total"}[1m]))))) < 0.95'
+                severity: warning
+                for: 10m
+
+              #
+              # Performance and errors (RED)
+              #
+              - name: Grafana Alloy OpenTelemetry receiver refusing data
+                description: The OpenTelemetry receiver in Alloy under job {{ $labels.job }} has a success rate below 95% for pushing spans, metrics, or logs into the pipeline, meaning telemetry data is being dropped, possibly due to limits imposed by otelcol.processor.memory_limiter.
+                query: '(1 - (sum by (job) (rate({__name__=~"otelcol_receiver_refused_(spans|metric_points|log_records)_total"}[1m])) / (sum by (job) (rate({__name__=~"otelcol_receiver_refused_(spans|metric_points|log_records)_total"}[1m])) + sum by (job) (rate({__name__=~"otelcol_receiver_accepted_(spans|metric_points|log_records)_total"}[1m]))))) < 0.95'
+                severity: critical
+                for: 10m
               - name: Grafana Alloy unhealthy components
                 description: One or more Alloy pipeline components (receivers, exporters, processors, discovery, etc.) under job {{ $labels.job }} are reporting a non-healthy status, even though the Alloy process itself is still running.
                 query: 'sum by (job) (alloy_component_controller_running_components{health_type!="healthy"}) > 0'
@@ -6775,16 +7654,6 @@ groups:
                 query: "cluster_node_gossip_health_score > 0"
                 severity: warning
                 for: 10m
-              - name: Grafana Alloy OpenTelemetry receiver refusing data
-                description: The OpenTelemetry receiver in Alloy under job {{ $labels.job }} has a success rate below 95% for pushing spans, metrics, or logs into the pipeline, meaning telemetry data is being dropped, possibly due to limits imposed by otelcol.processor.memory_limiter.
-                query: '(1 - (sum by (job) (rate({__name__=~"otelcol_receiver_refused_(spans|metric_points|log_records)_total"}[1m])) / (sum by (job) (rate({__name__=~"otelcol_receiver_refused_(spans|metric_points|log_records)_total"}[1m])) + sum by (job) (rate({__name__=~"otelcol_receiver_accepted_(spans|metric_points|log_records)_total"}[1m]))))) < 0.95'
-                severity: critical
-                for: 10m
-              - name: Grafana Alloy OpenTelemetry exporter failing to send data
-                description: The OpenTelemetry exporter in Alloy under job {{ $labels.job }} has a success rate below 95% for sending spans, metrics, or logs to their destination, meaning telemetry data delivery is failing, possibly due to a payload issue or an unreachable endpoint.
-                query: '(1 - (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) / (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) + sum by (job) (rate({__name__=~"otelcol_exporter_sent_(spans|metric_points|log_records)_total"}[1m]))))) < 0.95'
-                severity: warning
-                for: 10m
 
       - name: OpenTelemetry Collector
         logo: /images/services/opentelemetry-collector.svg
@@ -6797,6 +7666,9 @@ groups:
               These alerts monitor the collector's health when metrics are ingested via the Prometheus OTLP endpoint or scraped directly.
               All collector internal metrics are prefixed with 'otelcol_'.
             rules:
+              #
+              # Availability
+              #
               - name: OpenTelemetry Collector down
                 description: OpenTelemetry Collector instance has disappeared or is not being scraped
                 query: 'up{job=~".*otel.*collector.*"} == 0'
@@ -6804,6 +7676,19 @@ groups:
                 for: 1m
                 comments: |
                   Adjust the job label regex to match the actual job name in your Prometheus scrape config.
+
+              #
+              # Resource saturation (USE)
+              #
+              - name: OpenTelemetry Collector high memory usage
+                description: "OpenTelemetry Collector memory usage is above 90%"
+                query: '(otelcol_process_runtime_heap_alloc_bytes / on(instance, job) otelcol_process_runtime_total_sys_memory_bytes) > 0.9'
+                severity: warning
+                for: 5m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: OpenTelemetry Collector receiver refused spans
                 description: "OpenTelemetry Collector is refusing {{ $value | humanize }}/s spans on {{ $labels.receiver }}."
                 query: 'rate(otelcol_receiver_refused_spans[5m]) > 0.05'
@@ -6825,6 +7710,11 @@ groups:
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
                 severity: critical
                 for: 5m
+              - name: OpenTelemetry Collector OTLP receiver errors
+                description: "OpenTelemetry Collector OTLP receiver is completely failing - all spans are being refused"
+                query: 'rate(otelcol_receiver_accepted_spans{receiver=~"otlp"}[5m]) == 0 and rate(otelcol_receiver_refused_spans{receiver=~"otlp"}[5m]) > 0'
+                severity: critical
+                for: 2m
               - name: OpenTelemetry Collector exporter failed spans
                 description: "OpenTelemetry Collector failing to send {{ $value | humanize }}/s spans via {{ $labels.exporter }}."
                 query: 'rate(otelcol_exporter_send_failed_spans[5m]) > 0.05'
@@ -6866,16 +7756,6 @@ groups:
                   These processor metrics are deprecated since collector v0.110.0.
                 severity: warning
                 for: 5m
-              - name: OpenTelemetry Collector high memory usage
-                description: "OpenTelemetry Collector memory usage is above 90%"
-                query: '(otelcol_process_runtime_heap_alloc_bytes / on(instance, job) otelcol_process_runtime_total_sys_memory_bytes) > 0.9'
-                severity: warning
-                for: 5m
-              - name: OpenTelemetry Collector OTLP receiver errors
-                description: "OpenTelemetry Collector OTLP receiver is completely failing - all spans are being refused"
-                query: 'rate(otelcol_receiver_accepted_spans{receiver=~"otlp"}[5m]) == 0 and rate(otelcol_receiver_refused_spans{receiver=~"otlp"}[5m]) > 0'
-                severity: critical
-                for: 2m
               - name: OpenTelemetry Collector exporter enqueue failed spans
                 description: OpenTelemetry Collector exporter {{ $labels.exporter }} is dropping {{ $value | humanize }}/s spans because its sending queue is full and rejects new items before they can be queued.
                 query: "rate(otelcol_exporter_enqueue_failed_spans_total[5m]) > 0.05"
@@ -6904,6 +7784,29 @@ groups:
               For span ingestion pipeline alerts (refused spans, export failures, queue saturation),
               use the OpenTelemetry Collector rules instead.
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: Jaeger storage completely unavailable
+                description: "Jaeger on {{ $labels.instance }} has 100% storage errors for {{ $labels.operation }} — storage backend may be down."
+                query: 'sum(rate(jaeger_storage_requests_total{result="err"}[1m])) by (instance, job, namespace, operation) > 0 and sum(rate(jaeger_storage_requests_total{result="ok"}[1m])) by (instance, job, namespace, operation) == 0'
+                severity: critical
+                for: 2m
+                comments: |
+                  Fires when all storage operations for a given type are failing and none are succeeding.
+                  Indicates the storage backend (Cassandra, Elasticsearch, etc.) is likely unreachable or misconfigured.
+              - name: Jaeger no storage reads succeeding
+                description: "Jaeger on {{ $labels.instance }} has no successful storage reads for {{ $labels.operation }} in the past 15 minutes."
+                query: 'sum(increase(jaeger_storage_requests_total{result="ok"}[15m])) by (instance, job, namespace, operation) == 0 and sum(increase(jaeger_storage_requests_total[15m])) by (instance, job, namespace, operation) > 0'
+                severity: warning
+                for: 5m
+                comments: |
+                  Fires when an operation (e.g. find_traces, get_services) has received requests but none succeeded.
+                  May indicate a persistent storage error or a backend that is slow to recover.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: Jaeger high storage error rate
                 description: "Jaeger on {{ $labels.instance }} is experiencing {{ $value | humanize }}% storage errors on {{ $labels.operation }}."
                 query: '100 * sum(rate(jaeger_storage_requests_total{result="err"}[1m])) by (instance, job, namespace, operation) / sum(rate(jaeger_storage_requests_total[1m])) by (instance, job, namespace, operation) > 1 and sum(rate(jaeger_storage_requests_total[1m])) by (instance, job, namespace, operation) > 0'
@@ -6931,14 +7834,6 @@ groups:
                 for: 5m
                 comments: |
                   Threshold of 2s is a rough default. Adjust based on your storage backend and data volume.
-              - name: Jaeger storage completely unavailable
-                description: "Jaeger on {{ $labels.instance }} has 100% storage errors for {{ $labels.operation }} — storage backend may be down."
-                query: 'sum(rate(jaeger_storage_requests_total{result="err"}[1m])) by (instance, job, namespace, operation) > 0 and sum(rate(jaeger_storage_requests_total{result="ok"}[1m])) by (instance, job, namespace, operation) == 0'
-                severity: critical
-                for: 2m
-                comments: |
-                  Fires when all storage operations for a given type are failing and none are succeeding.
-                  Indicates the storage backend (Cassandra, Elasticsearch, etc.) is likely unreachable or misconfigured.
               - name: Jaeger slow single trace retrieval
                 description: "Jaeger on {{ $labels.instance }} p99 latency for single trace retrieval is {{ $value | humanizeDuration }}."
                 query: 'histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{http_route="/api/traces/{traceID}"}[5m])) by (le, instance, job, namespace)) > 5'
@@ -6955,14 +7850,6 @@ groups:
                 comments: |
                   Errors on /api/services indicate the storage backend cannot return the list of instrumented services,
                   which breaks the Jaeger UI service selector.
-              - name: Jaeger no storage reads succeeding
-                description: "Jaeger on {{ $labels.instance }} has no successful storage reads for {{ $labels.operation }} in the past 15 minutes."
-                query: 'sum(increase(jaeger_storage_requests_total{result="ok"}[15m])) by (instance, job, namespace, operation) == 0 and sum(increase(jaeger_storage_requests_total[15m])) by (instance, job, namespace, operation) > 0'
-                severity: warning
-                for: 5m
-                comments: |
-                  Fires when an operation (e.g. find_traces, get_services) has received requests but none succeeded.
-                  May indicate a persistent storage error or a backend that is slow to recover.
           - name: Embedded exporter (legacy, <v2)
             slug: embedded-exporter-legacy
             doc_url: https://www.jaegertracing.io/docs/1.x/monitoring/
@@ -6972,6 +7859,9 @@ groups:
               For Jaeger v2+, use the "Embedded exporter (v2+)" rules instead.
               Note: jaeger-agent was deprecated in v1.35 and removed in v2.0.
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Jaeger agent HTTP server errors
                 description: "Jaeger agent on {{ $labels.instance }} is experiencing {{ $value | humanize }}% HTTP server errors."
                 query: '100 * sum(rate(jaeger_agent_http_server_errors_total[1m])) by (instance, job, namespace) / sum(rate(jaeger_agent_http_server_total[1m])) by (instance, job, namespace) > 1 and sum(rate(jaeger_agent_http_server_total[1m])) by (instance, job, namespace) > 0'
@@ -7047,6 +7937,22 @@ groups:
             slug: apcupsd_exporter
             doc_url: https://github.com/mdlayher/apcupsd_exporter
             rules:
+              #
+              # Resource saturation (USE)
+              #
+              - name: APC UPS low battery voltage
+                description: Battery voltage is lower than nominal (< 95%)
+                query: "(apcupsd_battery_volts / apcupsd_battery_nominal_volts) < 0.95 and apcupsd_battery_nominal_volts > 0"
+                severity: warning
+              - name: APC UPS high temperature
+                description: Internal temperature is high ({{$value}}°C)
+                query: "apcupsd_internal_temperature_celsius >= 40"
+                severity: warning
+                for: 2m
+
+              #
+              # Performance and errors (RED)
+              #
               - name: APC UPS Battery nearly empty
                 description: Battery is almost empty (< 10% left)
                 query: "apcupsd_battery_charge_percent < 10"
@@ -7059,15 +7965,6 @@ groups:
                 description: UPS now running on battery (since {{$value | humanizeDuration}})
                 query: "apcupsd_battery_time_on_seconds > 0"
                 severity: warning
-              - name: APC UPS low battery voltage
-                description: Battery voltage is lower than nominal (< 95%)
-                query: "(apcupsd_battery_volts / apcupsd_battery_nominal_volts) < 0.95 and apcupsd_battery_nominal_volts > 0"
-                severity: warning
-              - name: APC UPS high temperature
-                description: Internal temperature is high ({{$value}}°C)
-                query: "apcupsd_internal_temperature_celsius >= 40"
-                severity: warning
-                for: 2m
               - name: APC UPS high load
                 description: UPS load is > 80%
                 query: "apcupsd_ups_load_percent > 80"
@@ -7079,6 +7976,9 @@ groups:
           - name: Embedded exporter
             slug: embedded-exporter
             rules:
+              #
+              # Performance and errors (RED)
+              #
               - name: Provider failed because net_version failed
                 description: "Failed net_version for Provider `{{$labels.provider}}` in Graph node `{{$labels.instance}}`"
                 query: "eth_rpc_status == 1"
@@ -7095,12 +7995,6 @@ groups:
                 description: "Timeout to get genesis for Provider `{{$labels.provider}}` in Graph node `{{$labels.instance}}`"
                 query: "eth_rpc_status == 4"
                 severity: critical
-              - name: Store connection slow
-                description: "Store connection is too slow to `{{$labels.pool}}` pool, `{{$labels.shard}}` shard in Graph node `{{$labels.instance}}`"
-                query: "store_connection_wait_time_ms > 10"
-                severity: warning
-                comments: |
-                  Threshold of 10ms. Adjust based on your expected database latency.
               - name: Store connection very slow
                 description: "Store connection is very slow to `{{$labels.pool}}` pool, `{{$labels.shard}}` shard in Graph node `{{$labels.instance}}`"
                 query: "store_connection_wait_time_ms > 20"
@@ -7114,6 +8008,12 @@ groups:
                 comments: |
                   Requires graph-node >= 0.37.0. The deployment_status gauge (1=starting, 2=running,
                   3=stopped, 4=failed) replaced the older deployment_failed metric, which was removed.
+              - name: Store connection slow
+                description: "Store connection is too slow to `{{$labels.pool}}` pool, `{{$labels.shard}}` shard in Graph node `{{$labels.instance}}`"
+                query: "store_connection_wait_time_ms > 10"
+                severity: warning
+                comments: |
+                  Threshold of 10ms. Adjust based on your expected database latency.
               - name: Subgraph indexing lag behind chain head
                 description: Subgraph deployment `{{$labels.deployment}}` is more than 100 blocks behind the `{{$labels.network}}` chain head in Graph node `{{$labels.instance}}`, indicating indexing is stalled or too slow to keep up with new blocks.
                 query: "ethereum_chain_head_number - ignoring(deployment,shard) group_right(deployment,shard) deployment_head > 100"
@@ -7126,6 +8026,9 @@ groups:
           - slug: embedded-exporter
             doc_url: https://docs.litellm.ai/docs/proxy/prometheus
             rules:
+              #
+              # Availability
+              #
               - name: LiteLLM provider spend over budget
                 description: "Cumulative spend for an LLM provider has exceeded the daily budget threshold. Replace the regex `(claude-|anthropic/).*` with your provider's model-name pattern. Useful as a soft-warning when `provider_budget_config` hard-cap is unavailable or disabled."
                 query: 'sum(increase(litellm_spend_metric_total{model=~"(claude-|anthropic/).*"}[24h])) > 1'
@@ -7135,6 +8038,10 @@ groups:
                   The threshold (1) is in USD. The `model` label carries the resolved model-name (post-routing). 
                   PromQL `increase()` requires ≥2 datapoints with growth-difference to extrapolate positive — 
                   for brand-new counter series this needs ≥2 distinct request bursts ≥1 scrape-cycle apart.
+
+              #
+              # Performance and errors (RED)
+              #
               - name: LiteLLM proxy failed requests rate high
                 description: "LiteLLM proxy is returning failed responses to clients (>5% error rate over 5min). Investigate downstream LLM provider availability or auth issues."
                 query: 'sum(rate(litellm_proxy_failed_requests_metric_total[5m])) / sum(rate(litellm_proxy_total_requests_metric_total[5m])) > 0.05'

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -48,7 +48,6 @@ groups:
                 description: A Prometheus AlertManager job has disappeared
                 query: 'absent(up{job="alertmanager"})'
                 severity: warning
-
               #
               # Resource saturation (USE)
               #
@@ -56,7 +55,6 @@ groups:
                 description: Prometheus is dropping samples because their timestamps arrive out of order ({{ $value }} samples in the last 5 minutes), indicating a misbehaving target or clock skew.
                 query: "increase(prometheus_target_scrapes_sample_out_of_order_total[5m]) > 3"
                 severity: warning
-
               #
               # Performance and errors (RED)
               #
@@ -176,7 +174,6 @@ groups:
                 query: "prometheus_engine_queries / prometheus_engine_queries_concurrent_max > 0.8"
                 severity: warning
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -357,7 +354,6 @@ groups:
                 query: "(min_over_time(node_timex_sync_status[3m]) == 0 and node_timex_maxerror_seconds >= 16)"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -423,7 +419,6 @@ groups:
                 description: 'Host {{ $labels.instance }} has had {{ printf "%.0f" $value }} correctable memory errors reported by EDAC in the last 1 minute.'
                 query: "(increase(node_edac_correctable_errors_total[1m]) > 0)"
                 severity: info
-
               #
               # Info, security, and config
               #
@@ -467,7 +462,6 @@ groups:
                 description: Device temperature at 80% of trip value on {{ $labels.instance }} drive {{ $labels.device }}
                 query: 'max_over_time(smartctl_device_temperature{temperature_type="current"} [10m]) >= on(device, instance) (smartctl_device_temperature{temperature_type="drive_trip"} * .80)'
                 severity: warning
-
               #
               # Performance and errors (RED)
               #
@@ -509,7 +503,6 @@ groups:
                 for: 5m
                 comments: |
                   The ipmi_up metric is per-collector. A value of 0 means the collector could not retrieve data from the BMC.
-
               #
               # Resource saturation (USE)
               #
@@ -615,7 +608,6 @@ groups:
                 for: 5m
                 comments: |
                   This rule can be very noisy in dynamic infra with legitimate container start/stop/deployment.
-
               #
               # Resource saturation (USE)
               #
@@ -656,7 +648,6 @@ groups:
                 query: '(1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total) BY (instance))) * 100 > 80 and sum(container_fs_inodes_total) BY (instance) > 0'
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -692,7 +683,6 @@ groups:
                 description: Blackbox probe has had lower uptime than 99.9% over the last 30 days, which may indicate cumulative outages or repeated flapping not caught by immediate down alerts.
                 query: 'avg_over_time(probe_success{job="blackbox-exporter"}[30d]) * 100 < 99.9'
                 severity: info
-
               #
               # Performance and errors (RED)
               #
@@ -711,7 +701,6 @@ groups:
                 query: "sum by (instance) (probe_icmp_duration_seconds) > 1"
                 severity: warning
                 for: 1m
-
               #
               # Info, security, and config
               #
@@ -771,7 +760,6 @@ groups:
                 query: "windows_time_ntp_round_trip_delay_seconds > 1"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -784,7 +772,6 @@ groups:
                 query: 'windows_service_state{state="running"} == 0'
                 severity: critical
                 for: 1m
-
               #
               # Info, security, and config
               #
@@ -814,7 +801,6 @@ groups:
                 query: "vmware_vm_mem_usage_average / 100 >= 90 and vmware_vm_mem_usage_average / 100 < 95"
                 severity: warning
                 for: 10m
-
               #
               # Capacity and trend
               #
@@ -860,7 +846,6 @@ groups:
                   This alert triggers for all VMs and containers that are not running.
                   You may want to filter by specific guests using the `id` label, or exclude
                   intentionally stopped guests with additional label matchers.
-
               #
               # Resource saturation (USE)
               #
@@ -884,7 +869,6 @@ groups:
                 query: 'pve_disk_usage_bytes{id=~"storage/.*"} / pve_disk_size_bytes{id=~"storage/.*"} * 100 > 80 and pve_disk_size_bytes{id=~"storage/.*"} > 0'
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -892,7 +876,6 @@ groups:
                 description: 'Proxmox VE replication for {{ $labels.id }} has {{ $value }} failed sync(s).'
                 query: 'pve_replication_failed_syncs > 0'
                 severity: warning
-
               #
               # Capacity and trend
               #
@@ -950,7 +933,6 @@ groups:
                 query: "netdata_md_mismatch_cnt_unsynchronized_blocks_average > 1024"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -974,7 +956,6 @@ groups:
                 query: 'ebpf_exporter_enabled_configs == 0 or absent(ebpf_exporter_enabled_configs)'
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -1006,7 +987,6 @@ groups:
                 query: 'namedprocess_namegroup_num_procs == 0'
                 severity: warning
                 for: 5m
-
               #
               # Resource saturation (USE)
               #
@@ -1055,7 +1035,6 @@ groups:
                 for: 5m
                 comments: |
                   Filters to voluntary switches only — involuntary switches are normal under CPU contention. Threshold of 50000/s is a rough default. Adjust based on workload.
-
               #
               # Performance and errors (RED)
               #
@@ -1097,7 +1076,6 @@ groups:
                 for: 2m
                 comments: |
                   Threshold of 100 connections is arbitrary. Adjust to your workload.
-
               #
               # Performance and errors (RED)
               #
@@ -1164,7 +1142,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Resource saturation (USE)
               #
@@ -1183,7 +1160,6 @@ groups:
                 query: "max_over_time(mysql_global_status_threads_running[1m]) / mysql_global_variables_max_connections * 100 > 60 and mysql_global_variables_max_connections > 0"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1247,7 +1223,6 @@ groups:
                 query: "rate(mysql_global_status_questions[1m]) > 10000"
                 severity: info
                 for: 2m
-
               #
               # Capacity and trend
               #
@@ -1256,7 +1231,6 @@ groups:
                 query: "mysql_global_status_wsrep_local_state != 4 and mysql_global_variables_wsrep_desync == 0"
                 severity: warning
                 for: 2m
-
               #
               # Info, security, and config
               #
@@ -1287,7 +1261,6 @@ groups:
                 description: The replication role (primary/replica) of {{ $labels.instance }} has just changed, which usually indicates a failover happened. Verify whether this was expected.
                 query: "pg_replication_is_replica and changes(pg_replication_is_replica[1m]) > 0"
                 severity: warning
-
               #
               # Resource saturation (USE)
               #
@@ -1335,7 +1308,6 @@ groups:
                 query: "sum by (instance, job, server) (pg_stat_activity_count) > min by (instance, job, server) ((pg_settings_max_connections - pg_settings_superuser_reserved_connections) * 0.8)"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1402,7 +1374,6 @@ groups:
                 query: "rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) / (rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) + rate(pg_stat_bgwriter_checkpoints_req_total[5m])) < 0.5 and (rate(pg_stat_bgwriter_checkpoints_timed_total[5m]) + rate(pg_stat_bgwriter_checkpoints_req_total[5m])) > 0"
                 severity: warning
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -1434,7 +1405,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Performance and errors (RED)
               #
@@ -1461,7 +1431,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Resource saturation (USE)
               #
@@ -1475,7 +1444,6 @@ groups:
                 query: "oracledb_tablespace_used_percent > 85"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -1567,7 +1535,6 @@ groups:
                 query: "100 * (sum without (database, user) (pgbouncer_pools_server_active_connections + pgbouncer_pools_server_idle_connections + pgbouncer_pools_server_used_connections) / clamp_min(pgbouncer_config_max_user_connections,1)) > 80"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1628,7 +1595,6 @@ groups:
                 query: "redis_cluster_slots_fail > 0"
                 severity: warning
                 for: 5m
-
               #
               # Resource saturation (USE)
               #
@@ -1659,7 +1625,6 @@ groups:
                 query: "redis_connected_clients < 5"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1672,7 +1637,6 @@ groups:
                 query: "redis_cluster_slots_pfail > 0"
                 severity: warning
                 for: 5m
-
               #
               # Capacity and trend
               #
@@ -1698,7 +1662,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Resource saturation (USE)
               #
@@ -1719,7 +1682,6 @@ groups:
                 query: "(memcached_current_connections / memcached_max_connections * 100) > 80 and memcached_max_connections > 0"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1791,7 +1753,6 @@ groups:
                   mongodb_rs_myState (this node's replica set state) is exposed in default mode.
                   Restricted to == 1 (PRIMARY) so the alert fires once per election, from the new primary's series, instead of on every member state transition (e.g. a secondary's restart/resync cycle).
                   Older exporters (or --compatible-mode) instead expose mongodb_mongod_replset_my_state.
-
               #
               # Resource saturation (USE)
               #
@@ -1800,7 +1761,6 @@ groups:
                 query: 'mongodb_ss_connections{conn_type="current"} / (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) * 100 > 80 and (mongodb_ss_connections{conn_type="current"} + mongodb_ss_connections{conn_type="available"}) > 0'
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1856,7 +1816,6 @@ groups:
                 description: MongoDB Replication set member as seen from another member of the set, is unreachable
                 query: "mongodb_replset_member_state == 8"
                 severity: critical
-
               #
               # Resource saturation (USE)
               #
@@ -1865,7 +1824,6 @@ groups:
                 query: 'mongodb_connections{state="current"} / (mongodb_connections{state="current"} + mongodb_connections{state="available"}) * 100 > 80 and (mongodb_connections{state="current"} + mongodb_connections{state="available"}) > 0'
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -1939,7 +1897,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Resource saturation (USE)
               #
@@ -1967,7 +1924,6 @@ groups:
                 query: "elasticsearch_filesystem_data_available_bytes / elasticsearch_filesystem_data_size_bytes * 100 < 20 and elasticsearch_filesystem_data_size_bytes > 0"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -2078,7 +2034,6 @@ groups:
                 query: "sum by (cluster, instance, node) (round((1 - (opensearch_fs_path_available_bytes / opensearch_fs_path_total_bytes)) * 100, 0.001)) > 85"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -2155,7 +2110,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Performance and errors (RED)
               #
@@ -2231,7 +2185,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Performance and errors (RED)
               #
@@ -2306,7 +2259,6 @@ groups:
                 for: 2m
                 comments: |
                   A low key cache hit rate increases disk I/O. Threshold is workload-dependent — adjust based on your data access patterns.
-
               #
               # Info, security, and config
               #
@@ -2355,7 +2307,6 @@ groups:
                 query: "ClickHouseMetrics_ZooKeeperSession != 1"
                 severity: warning
                 for: 3m
-
               #
               # Resource saturation (USE)
               #
@@ -2398,7 +2349,6 @@ groups:
                 for: 5m
                 comments: |
                   Please replace the threshold with an appropriate value
-
               #
               # Performance and errors (RED)
               #
@@ -2441,7 +2391,6 @@ groups:
                 query: "increase(ClickHouseProfileEvents_DelayedInserts[5m]) > 10"
                 severity: warning
                 for: 2m
-
               #
               # Capacity and trend
               #
@@ -2450,7 +2399,6 @@ groups:
                 query: "ClickHouseAsyncMetrics_DiskAvailable_backups / (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) * 100 < 20 and (ClickHouseAsyncMetrics_DiskAvailable_backups + ClickHouseAsyncMetrics_DiskUsed_backups) > 0"
                 severity: warning
                 for: 2m
-
               #
               # Info, security, and config
               #
@@ -2478,7 +2426,6 @@ groups:
                 query: "couchdb_httpd_node_up == 0 or couchdb_httpd_up == 0"
                 severity: critical
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -2499,7 +2446,6 @@ groups:
                 query: "process_open_fds / process_max_fds > 0.85 and process_max_fds > 0"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -2621,7 +2567,6 @@ groups:
                 query: "max by (collection, shard) (solr_collections_shard_leader) < 1"
                 severity: critical
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -2640,7 +2585,6 @@ groups:
                 query: 'min by (base_url) (solr_metrics_core_fs_bytes{item="usableSpace"}) / max by (base_url) (solr_metrics_core_fs_bytes{item="totalSpace"}) <= 0.2'
                 severity: warning
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -2691,7 +2635,6 @@ groups:
                 for: 1m
                 comments: |
                   1m delay allows a restart without triggering an alert.
-
               #
               # Resource saturation (USE)
               #
@@ -2730,7 +2673,6 @@ groups:
                 query: "(sum(rate(rabbitmq_connections_closed_total[5m])) + sum(rate(rabbitmq_connections_opened_total[5m]))) / sum(rabbitmq_connections) > 0.1 and sum(rabbitmq_connections) >= 100"
                 severity: warning
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -2794,7 +2736,6 @@ groups:
                 description: RabbitMQ cluster has a network partition ({{ $value }} partitions detected). Messages may be lost or duplicated.
                 query: "rabbitmq_partitions > 0"
                 severity: critical
-
               #
               # Resource saturation (USE)
               #
@@ -2808,7 +2749,6 @@ groups:
                 query: "rabbitmq_connections > 1000"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -2883,7 +2823,6 @@ groups:
                 description: "Zookeeper cluster has {{ $value }} nodes marked as leader (expected 1), indicating a split-brain"
                 query: "sum(zk_server_leader) > 1"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -2952,7 +2891,6 @@ groups:
                 comments: |
                   This metric name is path-dependent and may differ based on your BookKeeper data directory configuration.
                   Adjust the metric name to match your actual ledger directory path.
-
               #
               # Performance and errors (RED)
               #
@@ -3026,7 +2964,6 @@ groups:
                 comments: |
                   Replace job="nats" with the actual job name in your Prometheus configuration.
               # gnatsd_varz_cpu is a gauge, not a counter. Compare it directly, never wrap it in rate().
-
               #
               # Resource saturation (USE)
               #
@@ -3065,7 +3002,6 @@ groups:
                 comments: |
                   Only enable this alert if your deployment requires leaf node connections.
                   This will fire spuriously if leaf nodes are not configured.
-
               #
               # Performance and errors (RED)
               #
@@ -3147,7 +3083,6 @@ groups:
                 description: Apache down
                 query: "apache_up == 0"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -3193,7 +3128,6 @@ groups:
                 description: Server {{ $labels.server }} on {{ $labels.instance }} is repeatedly transitioning between UP and DOWN health-check states, which may indicate an unstable backend node or overly sensitive health-check thresholds.
                 query: "rate(haproxy_server_check_up_down_total[5m]) != 0"
                 severity: warning
-
               #
               # Performance and errors (RED)
               #
@@ -3252,7 +3186,6 @@ groups:
                 description: Some server healthcheck are failing on {{ $labels.server }} ({{ $value }} in the last 1m)
                 query: increase(haproxy_server_check_failures_total[1m]) > 2
                 severity: warning
-
               #
               # Capacity and trend
               #
@@ -3260,7 +3193,6 @@ groups:
                 description: HAProxy has no alive active or backup backends for {{ $labels.proxy }}
                 query: haproxy_backend_active_servers + haproxy_backend_backup_servers == 0
                 severity: critical
-
               #
               # Info, security, and config
               #
@@ -3293,7 +3225,6 @@ groups:
                 query: "avg by (backend) (haproxy_backend_http_total_time_average_seconds) > 1"
                 severity: warning
                 for: 1m
-
               #
               # Performance and errors (RED)
               #
@@ -3350,7 +3281,6 @@ groups:
                 description: Some server healthcheck are failing on {{ $labels.server }} ({{ $value }} in the last 1m)
                 query: "increase(haproxy_server_check_failures_total[1m]) > 2"
                 severity: warning
-
               #
               # Info, security, and config
               #
@@ -3374,7 +3304,6 @@ groups:
                 description: All Traefik services are down
                 query: "count(traefik_service_server_up) by (service) == 0"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -3388,7 +3317,6 @@ groups:
                 query: 'sum(rate(traefik_service_requests_total{code=~"5.*"}[3m])) by (service) / sum(rate(traefik_service_requests_total[3m])) by (service) * 100 > 5 and sum(rate(traefik_service_requests_total[3m])) by (service) > 0'
                 severity: critical
                 for: 1m
-
               #
               # Info, security, and config
               #
@@ -3416,7 +3344,6 @@ groups:
                 description: All Traefik backends are down
                 query: "count(traefik_backend_server_up) by (backend) == 0"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -3445,7 +3372,6 @@ groups:
                 description: "Caddy reverse proxy upstream {{ $labels.upstream }} is unhealthy"
                 query: "caddy_reverse_proxy_upstreams_healthy == 0"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -3475,7 +3401,6 @@ groups:
                 query: "envoy_server_live != 1"
                 severity: critical
                 for: 1m
-
               #
               # Resource saturation (USE)
               #
@@ -3492,7 +3417,6 @@ groups:
                 description: "Downstream connections are being rejected due to listener overflow on {{ $labels.instance }} ({{ $value }} in the last 5m)"
                 query: "increase(envoy_listener_downstream_cx_overflow[5m]) > 5"
                 severity: warning
-
               #
               # Performance and errors (RED)
               #
@@ -3559,7 +3483,6 @@ groups:
                 query: "envoy_cluster_outlier_detection_ejections_active > 0"
                 severity: info
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -3607,7 +3530,6 @@ groups:
                 query: 'absent(istio_build{component="pilot"})'
                 severity: critical
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -3749,7 +3671,6 @@ groups:
                 comments: |
                   process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not JVM-specific.
                   This alert will also fire for Go, Python, or any process exposing these metrics.
-
               #
               # Performance and errors (RED)
               #
@@ -3839,7 +3760,6 @@ groups:
                 query: 'go_memstats_stack_inuse_bytes > 1e9'
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -3903,7 +3823,6 @@ groups:
                 for: 5m
                 comments: |
                   Major GC rate > 5/s only fires if the app is essentially non-functional. Threshold of 2/s provides earlier detection.
-
               #
               # Performance and errors (RED)
               #
@@ -3955,7 +3874,6 @@ groups:
                 comments: |
                   process_open_fds and process_max_fds are generic metrics from the Prometheus client library, not Python-specific.
                   This alert will also fire for Go, JVM, or any process exposing these metrics.
-
               #
               # Performance and errors (RED)
               #
@@ -4002,7 +3920,6 @@ groups:
                 query: "flink_jobmanager_numRunningJobs == 0"
                 severity: critical
                 for: 1m
-
               #
               # Resource saturation (USE)
               #
@@ -4018,7 +3935,6 @@ groups:
                 query: "flink_jobmanager_Status_JVM_Memory_Heap_Used / flink_jobmanager_Status_JVM_Memory_Heap_Max > 0.9 and flink_jobmanager_Status_JVM_Memory_Heap_Max > 0"
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -4113,7 +4029,6 @@ groups:
                 comments: |
                   diskUsed is a gauge, not a counter — do not use rate(). Threshold of 1GB is a rough default.
                   Disk spilling indicates insufficient memory for the workload.
-
               #
               # Performance and errors (RED)
               #
@@ -4192,7 +4107,6 @@ groups:
                 query: "max without(job,name)(hadoop_namenode_missingblocks) > 0"
                 severity: critical
                 for: 5m
-
               #
               # Resource saturation (USE)
               #
@@ -4232,7 +4146,6 @@ groups:
                 description: "Available HDFS disk space is running low."
 
               # Alert rule for excessive MapReduce task failures
-
               #
               # Performance and errors (RED)
               #
@@ -4303,7 +4216,6 @@ groups:
                 severity: warning
                 comments: |
                   Threshold should be customized for each cronjob name.
-
               #
               # Resource saturation (USE)
               #
@@ -4336,7 +4248,6 @@ groups:
                 query: 'kube_node_status_condition{condition="NetworkUnavailable",status="true"} == 1'
                 severity: critical
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -4516,7 +4427,6 @@ groups:
                 description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} is constantly at minimum replicas for 50% of the time. Potential cost saving here.
                 query: "max(quantile_over_time(0.5, kube_horizontalpodautoscaler_status_desired_replicas[1d]) == kube_horizontalpodautoscaler_spec_min_replicas) by (horizontalpodautoscaler) > 3" # allow minimum 3 replicas running
                 severity: info
-
               #
               # Capacity and trend
               #
@@ -4525,7 +4435,6 @@ groups:
                 query: 'kube_resourcequota{type="used"} / ignoring(type) (kube_resourcequota{type="hard"} > 0) > 1'
                 severity: warning
                 for: 10m
-
               #
               # Info, security, and config
               #
@@ -4587,7 +4496,6 @@ groups:
                 description: A Consul agent is down
                 query: 'consul_health_node_status{status="critical"} == 1'
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -4630,7 +4538,6 @@ groups:
                 query: "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (instance, le)) > 1"
                 severity: critical
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -4649,7 +4556,6 @@ groups:
                 query: "(last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600"
                 severity: warning
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -4722,7 +4628,6 @@ groups:
                 for: 2m
               # without (instance) keeps the count scoped per etcd cluster: several clusters often share
               # a job label (main and events), and aggregating across them both misfires and masks.
-
               #
               # Capacity and trend
               #
@@ -4769,7 +4674,6 @@ groups:
                 query: 'openstack_cinder_agent_state{adminState="enabled"} == 0'
                 severity: critical
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -4801,7 +4705,6 @@ groups:
                 description: "Subnet {{ $labels.subnet_name }} on network {{ $labels.network_name }} has used over 90% of its IP pool"
                 query: 'openstack_neutron_network_ip_availabilities_used / openstack_neutron_network_ip_availabilities_total > 0.9 and openstack_neutron_network_ip_availabilities_total > 0'
                 severity: warning
-
               #
               # Performance and errors (RED)
               #
@@ -4843,7 +4746,6 @@ groups:
                 comments: |
                   This alert factors in the allocation ratio to compute effective capacity.
                   The threshold of 90% is a rough default. Adjust based on your allocation ratios and workload patterns.
-
               #
               # Capacity and trend
               #
@@ -5026,7 +4928,6 @@ groups:
                 severity: warning
                 for: 5m
               # HTTP request handling
-
               #
               # Resource saturation (USE)
               #
@@ -5085,7 +4986,6 @@ groups:
                 query: "puma_active_connections / puma_max_threads * 100 > 90 and puma_max_threads > 0"
                 severity: warning
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -5178,7 +5078,6 @@ groups:
                 query: "sum by (name) (sidekiq_queue_size) > 0"
                 severity: warning
                 for: 30m
-
               #
               # Info, security, and config
               #
@@ -5233,7 +5132,6 @@ groups:
                 for: 5m
                 comments: |
                   Brief throttling spikes are normal. Threshold of 0.1s/s (10% of CPU time throttled) filters out transient noise.
-
               #
               # Performance and errors (RED)
               #
@@ -5265,7 +5163,6 @@ groups:
                 query: 'histogram_quantile(0.95, sum(rate(grpc_server_handling_seconds_bucket{job="gitaly",grpc_type="unary"}[5m])) by (le)) > 1'
                 severity: warning
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -5289,7 +5186,6 @@ groups:
                 query: 'threadpool_blockingQueueSize > 0'
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -5401,7 +5297,6 @@ groups:
                 query: ssl_probe_success == 0
                 severity: critical
                 for: 1m
-
               #
               # Info, security, and config
               #
@@ -5433,7 +5328,6 @@ groups:
                 query: 'absent(up{job="cert-manager"})'
                 severity: critical
                 for: 10m
-
               #
               # Info, security, and config
               #
@@ -5472,7 +5366,6 @@ groups:
                 description: The switch appears to be down
                 query: junos_up == 0
                 severity: critical
-
               #
               # Resource saturation (USE)
               #
@@ -5501,7 +5394,6 @@ groups:
                 query: 'sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{rcode="SERVFAIL"}[5m])) / sum without (pod, instance, rcode) (rate(coredns_forward_responses_total[5m])) > 0.03'
                 severity: critical
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -5560,7 +5452,6 @@ groups:
                 query: "freeswitch_up == 0"
                 severity: critical
                 for: 1m
-
               #
               # Performance and errors (RED)
               #
@@ -5590,7 +5481,6 @@ groups:
                 query: "min(vault_autopilot_healthy) by (instance) == 0"
                 severity: critical
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -5694,7 +5584,6 @@ groups:
                 query: "cloudflare_zone_pool_health_status == 0"
                 severity: critical
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -5740,7 +5629,6 @@ groups:
                 query: '(ifOperStatus{job=~"snmp.*"} == 2) and on(instance, job, ifIndex) (ifAdminStatus{job=~"snmp.*"} == 1)'
                 severity: critical
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -5758,7 +5646,6 @@ groups:
                 for: 15m
                 comments: |
                   Threshold is a rough default. ifSpeed is a Gauge32 that maxes out at ~4.29 Gbps. For 10G+ interfaces, use ifHighSpeed (in Mbps) instead.
-
               #
               # Performance and errors (RED)
               #
@@ -5804,7 +5691,6 @@ groups:
                 for: 15m
                 comments: |
                   Metric name depends on Cilium version. Use cilium_unreachable_health_endpoints (older) or cilium_node_connectivity_status (1.14+).
-
               #
               # Resource saturation (USE)
               #
@@ -5819,7 +5705,6 @@ groups:
                 severity: info
                 for: 10m
                 comments: Policy denials may be expected behavior. Investigate only if unexpected traffic is being blocked.
-
               #
               # Performance and errors (RED)
               #
@@ -6007,7 +5892,6 @@ groups:
                   The threshold of 300 seconds (5 minutes) is a rough default. WireGuard peers that are idle but reachable
                   typically re-handshake every 2 minutes. Adjust based on your keepalive interval.
                   The `> 0` guard excludes peers that have never completed a handshake (covered by a separate rule).
-
               #
               # Performance and errors (RED)
               #
@@ -6056,7 +5940,6 @@ groups:
                 query: "count(ceph_mon_quorum_status == 0) <= (count(ceph_mon_metadata) - floor(count(ceph_mon_metadata) / 2 + 1))"
                 severity: warning
                 for: 2m
-
               #
               # Resource saturation (USE)
               #
@@ -6088,7 +5971,6 @@ groups:
                 query: 'ceph_health_detail{name="MON_CLOCK_SKEW"} == 1'
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -6167,7 +6049,6 @@ groups:
                 query: "ceph_healthcheck_slow_ops > 0"
                 severity: warning
                 for: 1m
-
               #
               # Capacity and trend
               #
@@ -6233,7 +6114,6 @@ groups:
                 description: OpenEBS LVM LocalPV volume group {{ $labels.instance }} is missing {{ $value }} underlying physical volume(s), which puts data at risk of loss.
                 query: "lvm_vg_missing_pv_count > 0"
                 severity: critical
-
               #
               # Performance and errors (RED)
               #
@@ -6266,7 +6146,6 @@ groups:
                 description: Minio erasure set has lost quorum, meaning MinIO can no longer guarantee reads or writes for objects in this pool/set until enough drives are restored.
                 query: "minio_cluster_health_erasure_set_status < 1"
                 severity: critical
-
               #
               # Resource saturation (USE)
               #
@@ -6286,7 +6165,6 @@ groups:
                   Uses usable capacity (post erasure-coding) rather than raw capacity, so the percentage
                   reflects how much data can actually still be stored, not the physical disk bytes
                   reserved for parity.
-
               #
               # Performance and errors (RED)
               #
@@ -6342,7 +6220,6 @@ groups:
                 comments: |
                   The threshold depends on the RDS instance class. Adjust based on your
                   instance type's max_connections parameter.
-
               #
               # Performance and errors (RED)
               #
@@ -6432,7 +6309,6 @@ groups:
                 description: "Stackdriver exporter has not successfully scraped metrics for project {{ $labels.project_id }} in the last 10 minutes."
                 query: "time() - stackdriver_monitoring_last_scrape_timestamp > 600"
                 severity: warning
-
               #
               # Capacity and trend
               #
@@ -6471,7 +6347,6 @@ groups:
                 query: "digitalocean_loadbalancer_status == 0"
                 severity: critical
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -6499,7 +6374,6 @@ groups:
                 query: "increase(digitalocean_errors_total[5m]) > 3"
                 severity: warning
                 for: 5m
-
               #
               # Capacity and trend
               #
@@ -6643,7 +6517,6 @@ groups:
                 query: '(up{job=~".*thanos-receive.*"} - 1) + on (job, instance) (sum by (job, instance) (increase(thanos_shipper_uploads_total{job=~".*thanos-receive.*"}[3h])) == 0)'
                 severity: critical
                 for: 3h
-
               #
               # Performance and errors (RED)
               #
@@ -6682,7 +6555,6 @@ groups:
                 query: '(sum by (job) (rate(thanos_receive_forward_requests_total{result="error"}[5m]))/  sum by (job) (rate(thanos_receive_forward_requests_total[5m]))) * 100 > 20 and sum by (job) (rate(thanos_receive_forward_requests_total[5m])) > 0'
                 severity: info
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -6707,7 +6579,6 @@ groups:
                 query: 'thanos_sidecar_prometheus_up == 0 and on (namespace, pod) prometheus_tsdb_data_replay_duration_seconds != 0'
                 severity: critical
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -6802,7 +6673,6 @@ groups:
                 query: 'time() -  max by (job, instance, group) (prometheus_rule_group_last_evaluation_timestamp_seconds{job=~".*thanos-rule.*"})>10 * max by (job, instance, group) (prometheus_rule_group_interval_seconds{job=~".*thanos-rule.*"})'
                 severity: info
                 for: 5m
-
               #
               # Info, security, and config
               #
@@ -6883,7 +6753,6 @@ groups:
                 query: "min(time() - (loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds > 0)) by (cluster, namespace) > 10800 or max(max_over_time(loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds[3h])) by (cluster, namespace) == 0"
                 severity: critical
                 for: 1h
-
               #
               # Performance and errors (RED)
               #
@@ -6959,7 +6828,6 @@ groups:
                 query: "100 * sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 1 and sum by (instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0"
                 severity: warning
                 for: 5m
-
               #
               # Resource saturation (USE)
               #
@@ -6968,7 +6836,6 @@ groups:
                 query: '(time() - thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 86400) and (thanos_objstore_bucket_last_successful_upload_time{job=~".+/compactor.*"} > 0)'
                 severity: critical
                 for: 15m
-
               #
               # Performance and errors (RED)
               #
@@ -7061,7 +6928,6 @@ groups:
                 query: "100 * (sum by (instance, job) (rate(cortex_ruler_write_requests_failed_total[5m])) / sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m]))) > 1 and sum by (instance, job) (rate(cortex_ruler_write_requests_total[5m])) > 0"
                 severity: critical
                 for: 5m
-
               #
               # Capacity and trend
               #
@@ -7072,7 +6938,6 @@ groups:
                 for: 1h
                 comments: |
                   Threshold of 0.05/s avoids firing on transient single-event spikes.
-
               #
               # Info, security, and config
               #
@@ -7258,7 +7123,6 @@ groups:
                   (5m by default) on every healthy cycle. The 6m average is what makes 200s meaningful: it
                   means the block-builder is burning roughly 45% of its cycle budget. Raise the window
                   alongside consume_cycle_duration if you tune it.
-
               #
               # Info, security, and config
               #
@@ -7294,7 +7158,6 @@ groups:
                 query: '100 * sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_missed_total[5m])) / sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 5 and sum by (instance, job) (rate(cortex_prometheus_rule_group_iterations_total[5m])) > 0'
                 severity: warning
                 for: 5m
-
               #
               # Resource saturation (USE)
               #
@@ -7344,7 +7207,6 @@ groups:
                 query: cortex_tcp_connections / cortex_tcp_connections_limit * 100 > 80 and cortex_tcp_connections_limit > 0
                 severity: critical
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -7592,7 +7454,6 @@ groups:
                 query: 'histogram_quantile(0.99, sum by (job, route, le) (rate(cortex_request_duration_seconds_bucket{route!~"ready|debug_pprof"}[5m]))) > 2.5'
                 severity: warning
                 for: 15m
-
               #
               # Info, security, and config
               #
@@ -7625,7 +7486,6 @@ groups:
                 query: '(1 - (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) / (sum by (job) (rate({__name__=~"otelcol_exporter_send_failed_(spans|metric_points|log_records)_total"}[1m])) + sum by (job) (rate({__name__=~"otelcol_exporter_sent_(spans|metric_points|log_records)_total"}[1m]))))) < 0.95'
                 severity: warning
                 for: 10m
-
               #
               # Performance and errors (RED)
               #
@@ -7676,7 +7536,6 @@ groups:
                 for: 1m
                 comments: |
                   Adjust the job label regex to match the actual job name in your Prometheus scrape config.
-
               #
               # Resource saturation (USE)
               #
@@ -7685,7 +7544,6 @@ groups:
                 query: '(otelcol_process_runtime_heap_alloc_bytes / on(instance, job) otelcol_process_runtime_total_sys_memory_bytes) > 0.9'
                 severity: warning
                 for: 5m
-
               #
               # Performance and errors (RED)
               #
@@ -7803,7 +7661,6 @@ groups:
                 comments: |
                   Fires when an operation (e.g. find_traces, get_services) has received requests but none succeeded.
                   May indicate a persistent storage error or a backend that is slow to recover.
-
               #
               # Performance and errors (RED)
               #
@@ -7949,7 +7806,6 @@ groups:
                 query: "apcupsd_internal_temperature_celsius >= 40"
                 severity: warning
                 for: 2m
-
               #
               # Performance and errors (RED)
               #
@@ -8038,7 +7894,6 @@ groups:
                   The threshold (1) is in USD. The `model` label carries the resolved model-name (post-routing). 
                   PromQL `increase()` requires ≥2 datapoints with growth-difference to extrapolate positive — 
                   for brand-new counter series this needs ≥2 distinct request bursts ≥1 scrape-cycle apart.
-
               #
               # Performance and errors (RED)
               #


### PR DESCRIPTION
## Summary
- Rules inside each exporter's `rules:` list are now ordered by a fixed category priority instead of ad hoc (add date / alphabetical / unclear): **Availability → Resource saturation (USE, grouped by resource) → Performance and errors (RED) → Capacity and trend → Info/security/config**, with severity as a secondary tie-break.
- Fixes the concrete pattern reported: e.g. Proxmox VE's quorum-loss check used to sit after CPU/memory/disk alerts instead of next to its other availability checks; disk "almost full" and "filling up" now stay adjacent instead of being separated by unrelated resources.
- `#` section-header comments now mark each category boundary inside a `rules:` list.
- Convention documented in `CLAUDE.md` under "Rule ordering within an exporter" so new/edited rules land in the right place going forward.

## Verification
- Pure permutation: every exporter's rule set was diffed against the pre-reorder file as a set (ignoring order) — 0 mismatches across all 112 exporters / 1156 rules. No rule content, query, severity, or threshold was changed.
- `npm run build` in `site/` completes successfully (115 pages generated) against the reordered `_data/rules.yml`.

## Test plan
- [x] Structural diff confirms every exporter's rule set is an exact permutation of the original (no additions/removals/edits)
- [x] `_data/rules.yml` parses as valid YAML
- [x] `npm run build` succeeds in `site/`
- [ ] Spot-check a few service pages on the deployed preview to confirm the new grouping reads well