### PR TITLE
remove duplicate host-and-hardware disk io rule

### DIFF
--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -272,10 +272,6 @@ groups:
                 query: "(node_filesystem_files_free / node_filesystem_files < .10 and ON (instance, device, mountpoint) node_filesystem_readonly == 0) and node_filesystem_files > 0"
                 severity: critical
                 for: 2m
-              - name: Host disk IO utilization high
-                description: Disk utilization is high (> 80%)
-                query: "(rate(node_disk_io_time_seconds_total[5m]) > .80)"
-                severity: warning
               - name: Host disk may fill in 24 hours
                 description: Filesystem will likely run out of space within the next 24 hours.
                 query: 'predict_linear(node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"}[3h], 86400) <= 0 and node_filesystem_avail_bytes > 0 and node_filesystem_readonly == 0'


### PR DESCRIPTION
## What

Removes "Host disk IO utilization high" from `_data/rules.yml` (host-and-hardware / node-exporter).

## Why

It's a duplicate of "Host unusual disk IO", a few entries below it in the same file:

- `Host disk IO utilization high`: `rate(node_disk_io_time_seconds_total[5m]) > .80`
- `Host unusual disk IO`: `rate(node_disk_io_time_seconds_total[5m]) > 0.8`

Same metric, same threshold, same severity (`warning`) — only the alert name/wording and `for:` differ. Any real disk-IO event fires both alerts, doubling notification volume for anyone consuming this rule set as-is (which is the intended use per the README).

Kept `Host unusual disk IO` rather than the other one, since its naming matches the rest of the disk-alert family already in this file (`Host unusual disk read latency`, `Host unusual disk write latency`, `Host unusual disk read rate`, `Host unusual disk write rate`).

## Test plan

- [x] `_data/rules.yml` still parses (existing `promtool-check` CI workflow validates rule syntax on this path)
- [x] No other rule in the repo references `Host disk IO utilization high` by name