### PR TITLE
Add OutageDeck alert rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Collection available here: **[https://samber.github.io/awesome-prometheus-alerts
 
 - [APC UPS](https://samber.github.io/awesome-prometheus-alerts/rules#apc-ups)
 - [Graph Node](https://samber.github.io/awesome-prometheus-alerts/rules#graph-node)
+- [OutageDeck](https://samber.github.io/awesome-prometheus-alerts/rules#outagedeck)
 
 ## 🤝 Contributing
 

--- a/_data/rules.yml
+++ b/_data/rules.yml
@@ -8317,3 +8317,44 @@ groups:
                 for: 10m
                 comments: |
                   10s threshold is a rough default; end-to-end latency depends heavily on which downstream LLM provider/model you route to — adjust based on your baseline.
+
+      - name: OutageDeck
+        logo: /images/services/outagedeck.svg
+        exporters:
+          - name: OutageDeck Prometheus exporter
+            slug: outagedeck-prometheus-exporter
+            doc_url: https://github.com/outagedeck/prometheus-exporter
+            rules:
+              #
+              # Availability
+              #
+              - name: OutageDeck provider disruption
+                description: "{{ $labels.name }} is degraded or reporting a partial outage according to its official status source."
+                query: "outagedeck_provider_status_code >= 3 and outagedeck_provider_status_code < 5"
+                severity: warning
+                for: 2m
+              - name: OutageDeck provider major outage
+                description: "{{ $labels.name }} is reporting a major outage according to its official status source."
+                query: "outagedeck_provider_status_code == 5"
+                severity: critical
+                for: 2m
+              - name: OutageDeck provider status unknown
+                description: "OutageDeck cannot normalize the current status reported for {{ $labels.name }}."
+                query: "outagedeck_provider_status_code == 0"
+                severity: warning
+                for: 10m
+              - name: OutageDeck service disruption
+                description: "{{ $labels.name }} is degraded or reporting an outage according to its official status source."
+                query: "outagedeck_service_status_code >= 3"
+                severity: warning
+                for: 2m
+              - name: OutageDeck refresh failed
+                description: "The OutageDeck exporter cannot refresh {{ $labels.provider }}, usually because the API is unavailable, rate-limited, or unreachable."
+                query: "outagedeck_scrape_success == 0"
+                severity: warning
+                for: 10m
+              - name: OutageDeck source data stale
+                description: "The latest official-source observation for {{ $labels.name }} is more than 15 minutes old, so its status may no longer be current."
+                query: "outagedeck_provider_source_age_seconds > 900"
+                severity: warning
+                for: 5m

--- a/site/public/images/services/outagedeck.svg
+++ b/site/public/images/services/outagedeck.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e293b" />
+      <stop offset="1" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <rect x="14" y="15" width="26" height="8" rx="4" fill="#f8fafc" />
+  <circle cx="46" cy="19" r="4.5" fill="#34d399" />
+  <rect x="14" y="28" width="36" height="8" rx="4" fill="#cbd5e1" />
+  <rect x="14" y="41" width="28" height="8" rx="4" fill="#64748b" />
+</svg>


### PR DESCRIPTION
## Summary

Add six copy-ready alerts for the [OutageDeck Prometheus exporter](https://github.com/outagedeck/prometheus-exporter):

- provider disruption and major-outage alerts with non-overlapping thresholds
- unknown provider state and service-level disruption alerts
- exporter refresh-failure and official-source freshness alerts
- the OutageDeck service icon and README index entry

Representative output from exporter v0.1.0:

```prometheus
outagedeck_provider_status_code{name="GitHub",provider="github"} 1
outagedeck_provider_active_incidents{name="AWS",provider="aws"} 2
outagedeck_service_status_code{name="EC2",provider="aws",service="aws-ec2"} 4
outagedeck_scrape_success{provider="github"} 1
```

## Validation

- `promtool check rules`: success, 6 rules found
- `_data/rules.yml`: parsed successfully as YAML
- `npm --prefix site run build`: success; generated `/rules/other/outagedeck/`
- Queries were exercised against the current v0.1.0 exporter and live OutageDeck provider data
