### PR TITLE
docs: cross-link sibling awesome lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 Collection available here: **[https://samber.github.io/awesome-prometheus-alerts](https://samber.github.io/awesome-prometheus-alerts)**
 
 See also:
-- [awesome-user-research](https://github.com/samber/awesome-user-research): tools for Product Managers and UX Researchers.
-- [awesome-ai-native](https://github.com/samber/awesome-ai-native): products where the LLM is the product itself.
+
+- [awesome-ai-native](https://github.com/samber/awesome-ai-native) - Products where the LLM is the product itself.
+- [awesome-olap](https://github.com/samber/awesome-olap) - OLAP databases, data lakes and data engineering tools.
+- [awesome-user-research](https://github.com/samber/awesome-user-research) - Tools for Product Managers and UX Researchers.
 
 <div align="center">
   <hr>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import { sponsors } from '../data/sponsors';
 import { data, getGroupSlug } from '../data/rules';
-import { SITE_NAME, SITE_URL, GITHUB_URL, GITHUB_CONTRIBUTING_URL, GITHUB_LICENSE_URL, GITHUB_MIT_LICENSE_URL, AUTHOR_GITHUB_URL, TWITTER_HANDLE, LICENSE_CC_BY_NAME, LICENSE_MIT_NAME } from '../data/site';
+import { SITE_NAME, SITE_URL, GITHUB_URL, GITHUB_CONTRIBUTING_URL, GITHUB_LICENSE_URL, GITHUB_MIT_LICENSE_URL, AUTHOR_GITHUB_URL, TWITTER_HANDLE, LICENSE_CC_BY_NAME, LICENSE_MIT_NAME, SIBLING_AWESOME_LISTS } from '../data/site';
 
 interface Props {
   base: string;
@@ -82,7 +82,17 @@ const featuredGroups = data.groups.filter((g) => featuredGroupSlugs.includes(get
       </div>
     </div>
 
-    <div class="mt-10 pt-6 border-t border-slate-200 dark:border-slate-800 flex flex-col sm:flex-row justify-between items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+    <div class="mt-10 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-400 dark:text-slate-500">
+      <span class="font-semibold uppercase tracking-wider">More awesome lists</span>
+      {SIBLING_AWESOME_LISTS.map((list, i) => (
+        <>
+          {i > 0 && <span aria-hidden="true">·</span>}
+          <a href={list.url} class="hover:text-brand dark:hover:text-brand-dark transition-colors">{list.name}</a>
+        </>
+      ))}
+    </div>
+
+    <div class="mt-6 pt-6 border-t border-slate-200 dark:border-slate-800 flex flex-col sm:flex-row justify-between items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
       <span>
         <a href={GITHUB_URL} class="hover:text-brand dark:hover:text-brand-dark transition-colors">awesome-prometheus-alerts</a>
         {' '}is maintained by{' '}

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -17,6 +17,13 @@ export const GITHUB_API_REPO_URL = 'https://api.github.com/repos/samber/awesome-
 export const GITHUB_CONTRIBUTING_URL = `${GITHUB_URL}/blob/master/CONTRIBUTING.md`;
 export const GITHUB_LICENSE_URL = `${GITHUB_URL}/blob/master/LICENSE`;
 
+// Sibling awesome lists maintained alongside this one, cross-linked from the footer.
+export const SIBLING_AWESOME_LISTS = [
+  { name: 'Awesome AI-Native', url: 'https://samber.github.io/awesome-ai-native/' },
+  { name: 'Awesome OLAP', url: 'https://samber.github.io/awesome-olap/' },
+  { name: 'Awesome User Research', url: 'https://samber.github.io/awesome-user-research/' },
+];
+
 // Licenses
 export const LICENSE_CC_BY_URL = 'https://creativecommons.org/licenses/by/4.0/';
 export const LICENSE_CC_BY_NAME = 'Creative Commons CC BY 4.0';


### PR DESCRIPTION
## Description

The four awesome lists share an audience but had no path between them: a reader landing on one had no way to discover the other three. This adds a discreet cross-reference in the two places a reader looks.

**Website** — a quiet line in `Footer.astro`, above the existing license bar, fed from a new `SIBLING_AWESOME_LISTS` constant in `data/site.ts` (matching how the rest of the footer sources its data):

> MORE AWESOME LISTS &nbsp; Awesome AI-Native · Awesome OLAP · Awesome User Research

Since every page goes through `BaseLayout` (directly or via `GuideLayout`), this lands on all 111 real pages. The only HTML files without it are the four legacy `*.html` redirect stubs, which are `noindex` meta-refreshes with no chrome.

Footer links point at the sibling **sites**, so internal linking stays on `samber.github.io`. README links point at the **repositories**.

**README** — the `See also:` block gains `awesome-olap`, is sorted alphabetically, and adopts the `- [name](url) - Description.` form used by the other three lists.

Verified with `astro check` (0 errors), `npm run lint` (clean), and a full `astro build`. The build's `fetchGithubStars` call cannot reach `api.github.com` from the sandbox, so page rendering was confirmed with that one call stubbed locally; the stub is not part of this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128P7a2QABz8fjhn8Bjojb2

---
_Generated by [Claude Code](https://claude.ai/code/session_0128P7a2QABz8fjhn8Bjojb2)_